### PR TITLE
Elasticsearch: Add PPL query builder and response parser

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -440,6 +440,7 @@ export class ElasticResponse {
             propNames,
             this.targets[0].timeField,
             isLogsRequest,
+            this.targetType,
             logMessageField,
             logLevelField
           );
@@ -557,6 +558,7 @@ export class ElasticResponse {
         flattenSchema,
         this.targets[0].timeField,
         isLogsRequest,
+        this.targetType,
         logMessageField,
         logLevelField
       );
@@ -681,18 +683,22 @@ const createEmptyDataFrame = (
   propNames: string[],
   timeField: string,
   isLogsRequest: boolean,
+  targetType: ElasticsearchQueryType,
   logMessageField?: string,
   logLevelField?: string
 ): MutableDataFrame => {
   const series = new MutableDataFrame({ fields: [] });
 
-  series.addField({
-    config: {
-      filterable: true,
-    },
-    name: timeField,
-    type: FieldType.time,
-  });
+  //PPL table response should add time field only when it is part of the query response
+  if (targetType === ElasticsearchQueryType.Lucene || isLogsRequest) {
+    series.addField({
+      config: {
+        filterable: true,
+      },
+      name: timeField,
+      type: FieldType.time,
+    });
+  }
 
   if (logMessageField) {
     series.addField({

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -493,7 +493,7 @@ export class ElasticResponse {
       }
     }
 
-    return { data: dataFrame };
+    return { data: dataFrame, key: this.targets[0]?.refId };
   }
 
   processResponseToSeries = () => {
@@ -531,7 +531,7 @@ export class ElasticResponse {
       }
     }
 
-    return { data: seriesList };
+    return { data: seriesList, key: this.targets[0]?.refId };
   };
 
   processPPLResponseToDataFrames(
@@ -576,7 +576,7 @@ export class ElasticResponse {
       series.refId = target.refId;
       dataFrame.push(series);
     }
-    return { data: dataFrame };
+    return { data: dataFrame, key: this.targets[0]?.refId };
   }
 
   processPPLResponseToSeries = () => {
@@ -599,7 +599,7 @@ export class ElasticResponse {
       refId: target.refId,
     };
 
-    return { data: [newSeries] };
+    return { data: [newSeries], key: this.targets[0]?.refId };
   };
 }
 

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -1,5 +1,5 @@
 import * as queryDef from './query_def';
-import { ElasticsearchAggregation } from './types';
+import { ElasticsearchAggregation, ElasticsearchQueryType } from './types';
 
 export class ElasticQueryBuilder {
   timeField: string;
@@ -188,6 +188,7 @@ export class ElasticQueryBuilder {
     target.metrics = target.metrics || [queryDef.defaultMetricAgg()];
     target.bucketAggs = target.bucketAggs || [queryDef.defaultBucketAgg()];
     target.timeField = this.timeField;
+    target.queryType = ElasticsearchQueryType.Lucene;
 
     let i, j, pv, nestedAggs, metric;
     const query = {
@@ -418,5 +419,60 @@ export class ElasticQueryBuilder {
       ...query,
       aggs: this.build(target, null, querystring).aggs,
     };
+  }
+
+  addPPLAdhocFilters(queryString: any, adhocFilters: any) {
+    let i, adhocquery;
+    let filter = [];
+
+    for (i = 0; i < adhocFilters.length; i++) {
+      filter.push(adhocFilters[i].key);
+      if (typeof adhocFilters[i].value === 'string') {
+        filter.push("'" + adhocFilters[i].value + "'");
+      } else {
+        filter.push(adhocFilters[i].value);
+      }
+      adhocquery = filter.join(adhocFilters[i].operator);
+      if (i > 0) {
+        queryString += ' and ' + adhocquery;
+      } else {
+        queryString += ' | where ' + adhocquery;
+      }
+      filter = [];
+    }
+    return queryString;
+  }
+
+  buildPPLQuery(target: any, adhocFilters?: any, queryString?: string) {
+    // make sure query has defaults
+    target.format = target.format || queryDef.defaultPPLFormat();
+    target.queryType = ElasticsearchQueryType.PPL;
+
+    // set isLogsQuery depending on the format
+    if (target.format === 'logs') {
+      target.isLogsQuery = true;
+    } else {
+      target.isLogsQuery = false;
+    }
+    if (adhocFilters) {
+      queryString = this.addPPLAdhocFilters(queryString, adhocFilters);
+    }
+
+    const timeRangeFilter = " | where `$timestamp`> timestamp('$timeFrom') and `$timestamp` < timestamp('$timeTo')";
+    //time range filter must be placed before other query filters
+    if (queryString) {
+      const separatorIndex = queryString.indexOf('|');
+      if (separatorIndex === -1) {
+        queryString = queryString.trimEnd() + timeRangeFilter;
+      } else {
+        queryString =
+          queryString.slice(0, separatorIndex).trimEnd() +
+          timeRangeFilter +
+          ' |' +
+          queryString.slice(separatorIndex + 1);
+      }
+    }
+
+    return { query: queryString };
   }
 }

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -458,7 +458,7 @@ export class ElasticQueryBuilder {
       queryString = this.addPPLAdhocFilters(queryString, adhocFilters);
     }
 
-    const timeRangeFilter = " | where `$timestamp`> timestamp('$timeFrom') and `$timestamp` < timestamp('$timeTo')";
+    const timeRangeFilter = " | where $timestamp > timestamp('$timeFrom') and $timestamp < timestamp('$timeTo')";
     //time range filter must be placed before other query filters
     if (queryString) {
       const separatorIndex = queryString.indexOf('|');

--- a/public/app/plugins/datasource/elasticsearch/query_def.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_def.ts
@@ -299,6 +299,10 @@ export function defaultBucketAgg() {
   return { type: 'date_histogram', id: '2', settings: { interval: 'auto' } };
 }
 
+export function defaultPPLFormat() {
+  return 'table';
+}
+
 export const findMetricById = (metrics: any[], id: any) => {
   return _.find(metrics, { id: id });
 };

--- a/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
@@ -1447,8 +1447,8 @@ describe('ElasticResponse', () => {
         };
       });
       expect(fields).toEqual([
-        { name: 'timestamp', type: 'time' },
         { name: 'test', type: 'string' },
+        { name: 'timestamp', type: 'string' },
       ]);
 
       let rows = new DataFrameView(logResults);

--- a/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
@@ -1404,6 +1404,40 @@ describe('ElasticResponse', () => {
     });
   });
 
+  describe('Invalid PPL time series query response', () => {
+    const targets: any = [
+      {
+        refId: 'A',
+        context: 'explore',
+        interval: '10s',
+        isLogsQuery: true,
+        key: 'Q-89d91614-009c-47b5-9945-39dd66ebcbf2-0',
+        liveStreaming: false,
+        query: 'source=sample_data | stats count(test) by data',
+        queryType: ElasticsearchQueryType.PPL,
+        timeField: 'timestamp',
+        format: 'time_series',
+      },
+    ];
+    const response = {
+      datarows: [
+        [5, 'data1'],
+        [1, 'data2'],
+        [4, 'data3'],
+      ],
+      schema: [
+        { name: 'test', type: 'string' },
+        { name: 'data', type: 'string' },
+      ],
+    };
+    const targetType = ElasticsearchQueryType.PPL;
+    it('should return invalid query error', () => {
+      expect(() => new ElasticResponse(targets, response, targetType).getTimeSeries()).toThrowError(
+        'Invalid time series query'
+      );
+    });
+  });
+
   describe('PPL table query response', () => {
     const targets: any = [
       {

--- a/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/elastic_response.test.ts
@@ -1,6 +1,7 @@
 import { DataFrameView, FieldCache, KeyValue, MutableDataFrame } from '@grafana/data';
 import { ElasticResponse } from '../elastic_response';
 import flatten from 'app/core/utils/flatten';
+import { ElasticsearchQueryType } from '../types';
 
 describe('ElasticResponse', () => {
   let targets: any;
@@ -1318,6 +1319,145 @@ describe('ElasticResponse', () => {
       const fieldCache = new FieldCache(result.data[0]);
       const field = fieldCache.getFieldByName('level');
       expect(field?.values.toArray()).toEqual(['debug', 'info']);
+    });
+  });
+
+  describe('PPL log query response', () => {
+    const targets: any = [
+      {
+        refId: 'A',
+        isLogsQuery: true,
+        queryType: ElasticsearchQueryType.PPL,
+        timeField: 'timestamp',
+        format: 'table',
+        query: 'source=sample_data_logs',
+      },
+    ];
+    const response = {
+      datarows: [
+        ['test-data1', 'message1'],
+        ['test-data2', 'message2'],
+        ['test-data3', 'message3'],
+      ],
+      schema: [
+        { name: 'data', type: 'string' },
+        { name: 'message', type: 'string' },
+      ],
+    };
+    const targetType = ElasticsearchQueryType.PPL;
+    it('should return all data', () => {
+      const result = new ElasticResponse(targets, response, targetType).getLogs();
+      expect(result.data.length).toBe(1);
+      const logResults = result.data[0] as MutableDataFrame;
+      const fields = logResults.fields.map(f => {
+        return {
+          name: f.name,
+          type: f.type,
+        };
+      });
+      expect(fields).toContainEqual({ name: 'data', type: 'string' });
+      expect(fields).toContainEqual({ name: 'message', type: 'string' });
+
+      let rows = new DataFrameView(logResults);
+      expect(rows.length).toBe(3);
+      for (let i = 0; i < rows.length; i++) {
+        const r = rows.get(i);
+        expect(r.data).toEqual(response.datarows[i][0]);
+        expect(r.message).toEqual(response.datarows[i][1]);
+      }
+    });
+  });
+
+  describe('PPL time series query response', () => {
+    const targets: any = [
+      {
+        refId: 'A',
+        context: 'explore',
+        interval: '10s',
+        isLogsQuery: true,
+        key: 'Q-89d91614-009c-47b5-9945-39dd66ebcbf2-0',
+        liveStreaming: false,
+        query: 'source=sample_data | stats count(test) by timestamp',
+        queryType: ElasticsearchQueryType.PPL,
+        timeField: 'timestamp',
+        format: 'time_series',
+      },
+    ];
+    const response = {
+      datarows: [
+        [5, '2020-11-01 00:39:02.912Z'],
+        [1, '2020-11-01 03:26:21.326Z'],
+        [4, '2020-11-01 03:34:43.399Z'],
+      ],
+      schema: [
+        { name: 'test', type: 'string' },
+        { name: 'timestamp', type: 'timestamp' },
+      ],
+    };
+    const targetType = ElasticsearchQueryType.PPL;
+    it('should return series', () => {
+      const result = new ElasticResponse(targets, response, targetType).getTimeSeries();
+      expect(result.data.length).toBe(1);
+      expect(result.data[0].datapoints.length).toBe(3);
+      expect(result.data[0].datapoints[0][0]).toBe(5);
+      expect(result.data[0].datapoints[0][1]).toBe(1604191142000);
+    });
+  });
+
+  describe('PPL table query response', () => {
+    const targets: any = [
+      {
+        refId: 'A',
+        context: 'explore',
+        interval: '10s',
+        isLogsQuery: false,
+        query: 'source=sample_data | stats count(test) by timestamp',
+        queryType: ElasticsearchQueryType.PPL,
+        timeField: 'timestamp',
+        format: 'table',
+      },
+    ];
+    const response = {
+      datarows: [
+        [5, '2020-11-01 00:39:02.912Z'],
+        [1, '2020-11-01 03:26:21.326Z'],
+        [4, '2020-11-01 03:34:43.399Z'],
+      ],
+      schema: [
+        { name: 'test', type: 'string' },
+        { name: 'timestamp', type: 'timestamp' },
+      ],
+    };
+    const targetType = ElasticsearchQueryType.PPL;
+
+    it('should create dataframes with filterable fields', () => {
+      const result = new ElasticResponse(targets, response, targetType).getTable();
+      for (const field of result.data[0].fields) {
+        expect(field.config.filterable).toBe(true);
+      }
+    });
+    it('should return all data', () => {
+      const result = new ElasticResponse(targets, response, targetType).getTable();
+      expect(result.data.length).toBe(1);
+      const logResults = result.data[0] as MutableDataFrame;
+      const fields = logResults.fields.map(f => {
+        return {
+          name: f.name,
+          type: f.type,
+        };
+      });
+      expect(fields).toEqual([
+        { name: 'timestamp', type: 'time' },
+        { name: 'test', type: 'string' },
+      ]);
+
+      let rows = new DataFrameView(logResults);
+      expect(rows.length).toBe(3);
+      for (let i = 0; i < rows.length; i++) {
+        const r = rows.get(i);
+        expect(r.test).toEqual(response.datarows[i][0]);
+        expect(r.timestamp).toEqual(response.datarows[i][1]);
+      }
     });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
@@ -615,7 +615,7 @@ describe('ElasticQueryBuilder', () => {
           const query = builder.buildPPLQuery(target, null, 'source=test');
 
           const expectedQuery = {
-            query: "source=test | where `$timestamp`> timestamp('$timeFrom') and `$timestamp` < timestamp('$timeTo')",
+            query: "source=test | where $timestamp > timestamp('$timeFrom') and $timestamp < timestamp('$timeTo')",
           };
           expect(query).toEqual(expectedQuery);
           expect(target.isLogsQuery).toEqual(true);
@@ -626,7 +626,7 @@ describe('ElasticQueryBuilder', () => {
 
           const expectedQuery = {
             query:
-              "source=test | where `$timestamp`> timestamp('$timeFrom') and `$timestamp` < timestamp('$timeTo') | where age > 18 | fields firstname",
+              "source=test | where $timestamp > timestamp('$timeFrom') and $timestamp < timestamp('$timeTo') | where age > 18 | fields firstname",
           };
           expect(query).toEqual(expectedQuery);
         });
@@ -640,7 +640,7 @@ describe('ElasticQueryBuilder', () => {
 
           const expectedQuery = {
             query:
-              "source=test | where `$timestamp`> timestamp('$timeFrom') and `$timestamp` < timestamp('$timeTo') | where key1='value1' and key2<50",
+              "source=test | where $timestamp > timestamp('$timeFrom') and $timestamp < timestamp('$timeTo') | where key1='value1' and key2<50",
           };
           expect(query).toEqual(expectedQuery);
         });
@@ -657,7 +657,7 @@ describe('ElasticQueryBuilder', () => {
           const query = builder.buildPPLQuery(target, null, 'source=test');
 
           const expectedQuery = {
-            query: "source=test | where `$timestamp`> timestamp('$timeFrom') and `$timestamp` < timestamp('$timeTo')",
+            query: "source=test | where $timestamp > timestamp('$timeFrom') and $timestamp < timestamp('$timeTo')",
           };
           expect(query).toEqual(expectedQuery);
           expect(target.isLogsQuery).toEqual(false);
@@ -672,7 +672,7 @@ describe('ElasticQueryBuilder', () => {
 
           const expectedQuery = {
             query:
-              "source=test | where `$timestamp`> timestamp('$timeFrom') and `$timestamp` < timestamp('$timeTo') | where key1='value1' and key2<50",
+              "source=test | where $timestamp > timestamp('$timeFrom') and $timestamp < timestamp('$timeTo') | where key1='value1' and key2<50",
           };
           expect(query).toEqual(expectedQuery);
         });

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
@@ -1,4 +1,5 @@
 import { ElasticQueryBuilder } from '../query_builder';
+import { ElasticsearchQueryType } from '../types';
 
 describe('ElasticQueryBuilder', () => {
   const builder = new ElasticQueryBuilder({ timeField: '@timestamp', esVersion: 2 });
@@ -600,6 +601,80 @@ describe('ElasticQueryBuilder', () => {
           expect(query.query.bool.filter[2].range['key4'].gt).toBe('value4');
           expect(query.query.bool.filter[3].regexp['key5']).toBe('value5');
           expect(query.query.bool.filter[4].bool.must_not.regexp['key6']).toBe('value6');
+        });
+      });
+
+      describe('build Logs PPL query', () => {
+        const target = {
+          queryType: ElasticsearchQueryType.PPL,
+          format: 'logs',
+          isLogsQuery: false,
+        };
+
+        it('should return default query and set isLogsQuery to true', () => {
+          const query = builder.buildPPLQuery(target, null, 'source=test');
+
+          const expectedQuery = {
+            query: "source=test | where `$timestamp`> timestamp('$timeFrom') and `$timestamp` < timestamp('$timeTo')",
+          };
+          expect(query).toEqual(expectedQuery);
+          expect(target.isLogsQuery).toEqual(true);
+        });
+
+        it('should return the query string', () => {
+          const query = builder.buildPPLQuery(target, null, 'source=test | where age > 18 | fields firstname');
+
+          const expectedQuery = {
+            query:
+              "source=test | where `$timestamp`> timestamp('$timeFrom') and `$timestamp` < timestamp('$timeTo') | where age > 18 | fields firstname",
+          };
+          expect(query).toEqual(expectedQuery);
+        });
+
+        it('should return the query with adhoc filters and time range filter', () => {
+          const adhocFilters = [
+            { key: 'key1', operator: '=', value: 'value1' },
+            { key: 'key2', operator: '<', value: 50 },
+          ];
+          const query = builder.buildPPLQuery({}, adhocFilters, 'source=test');
+
+          const expectedQuery = {
+            query:
+              "source=test | where `$timestamp`> timestamp('$timeFrom') and `$timestamp` < timestamp('$timeTo') | where key1='value1' and key2<50",
+          };
+          expect(query).toEqual(expectedQuery);
+        });
+      });
+
+      describe('build PPL time series query', () => {
+        const target = {
+          queryType: ElasticsearchQueryType.PPL,
+          format: 'time_series',
+          isLogsQuery: false,
+        };
+
+        it('should return default query', () => {
+          const query = builder.buildPPLQuery(target, null, 'source=test');
+
+          const expectedQuery = {
+            query: "source=test | where `$timestamp`> timestamp('$timeFrom') and `$timestamp` < timestamp('$timeTo')",
+          };
+          expect(query).toEqual(expectedQuery);
+          expect(target.isLogsQuery).toEqual(false);
+        });
+
+        it('should return the query with adhoc filters and time range filter', () => {
+          const adhocFilters = [
+            { key: 'key1', operator: '=', value: 'value1' },
+            { key: 'key2', operator: '<', value: 50 },
+          ];
+          const query = builder.buildPPLQuery({}, adhocFilters, 'source=test');
+
+          const expectedQuery = {
+            query:
+              "source=test | where `$timestamp`> timestamp('$timeFrom') and `$timestamp` < timestamp('$timeTo') | where key1='value1' and key2<50",
+          };
+          expect(query).toEqual(expectedQuery);
         });
       });
     });

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -9,6 +9,7 @@ export interface ElasticsearchOptions extends DataSourceJsonData {
   logMessageField?: string;
   logLevelField?: string;
   dataLinks?: DataLinkConfig[];
+  pplSupportEnabled?: boolean;
 }
 
 export interface ElasticsearchAggregation {
@@ -23,8 +24,10 @@ export interface ElasticsearchQuery extends DataQuery {
   isLogsQuery: boolean;
   alias?: string;
   query?: string;
+  queryType?: ElasticsearchQueryType;
   bucketAggs?: ElasticsearchAggregation[];
   metrics?: ElasticsearchAggregation[];
+  format?: string;
 }
 
 export type DataLinkConfig = {
@@ -32,3 +35,8 @@ export type DataLinkConfig = {
   url: string;
   datasourceUid?: string;
 };
+
+export enum ElasticsearchQueryType {
+  Lucene = 'lucene',
+  PPL = 'PPL',
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is one of several PRs targeting the elasticsearch-ppl-support-frontend branch, which should ultimately contain all the changes required for basic PPL support from the Elasticsearch plugin on the client-side. Basic PPL support entails being able to write PPL queries in the query editor and visualize responses from Elasticsearch instances with the ODFE SQL plugin installed. Expected functionality such as variable interpolation and ad hoc filtering should also work with PPL queries. Features that are out of scope for the elasticsearch-ppl-support-frontend branch include alerting on PPL queries and the option to use PPL queries in the dashboard settings menu.

This PR adds the functionality to build PPL queries and parse the response for visualization in Grafana. 
The PPL query is built with the dashboard time range filtering included as part of the default query string, and supports the use of ad hoc filters. The PPL response parser handles the response to support visualization of queries in the three different visualization format, which is chosen by the user through the query editor UI.

<img width="721" alt="image" src="https://user-images.githubusercontent.com/43913498/99606076-df7cfc00-29bd-11eb-9ef0-5cf07d233a5c.png">

<img width="847" alt="image" src="https://user-images.githubusercontent.com/43913498/99606035-c70ce180-29bd-11eb-83ba-cde352b7aadb.png">

<img width="462" alt="image" src="https://user-images.githubusercontent.com/43913498/99606158-0b987d00-29be-11eb-900e-d88edcd700e0.png">


**Which issue(s) this PR fixes:**

Partially resolves Grafana issue 28674

**Special notes for your reviewer:**

The relevant issue is not linked to avoid having this PR referenced in the issue conversation upstream.

cc: @alolita @robbierolin

