### PR TITLE
Elasticsearch: Add PPL query builder

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -431,27 +431,24 @@ export class ElasticQueryBuilder {
     target.queryType = ElasticsearchQueryType.PPL;
 
     // set isLogsQuery depending on the format
-    if (target.format === 'logs') {
-      target.isLogsQuery = true;
-    } else {
-      target.isLogsQuery = false;
-    }
+    target.isLogsQuery = target.format === 'logs';
+
     if (adhocFilters) {
       queryString = this.addPPLAdhocFilters(queryString, adhocFilters);
     }
 
-    const timeRangeFilter = " | where $timestamp > timestamp('$timeFrom') and $timestamp < timestamp('$timeTo')";
+    const timeRangeFilter = " where $timestamp > timestamp('$timeFrom') and $timestamp < timestamp('$timeTo')";
     //time range filter must be placed before other query filters
     if (queryString) {
       const separatorIndex = queryString.indexOf('|');
       if (separatorIndex === -1) {
-        queryString = queryString.trimEnd() + timeRangeFilter;
+        queryString = [queryString.trimEnd(), timeRangeFilter].join(' |');
       } else {
-        queryString =
-          queryString.slice(0, separatorIndex).trimEnd() +
-          timeRangeFilter +
-          ' |' +
-          queryString.slice(separatorIndex + 1);
+        queryString = [
+          queryString.slice(0, separatorIndex).trimEnd(),
+          timeRangeFilter,
+          queryString.slice(separatorIndex + 1),
+        ].join(' |');
       }
     }
 

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -188,6 +188,7 @@ export class ElasticQueryBuilder {
     target.metrics = target.metrics || [queryDef.defaultMetricAgg()];
     target.bucketAggs = target.bucketAggs || [queryDef.defaultBucketAgg()];
     target.timeField = this.timeField;
+    target.queryType = ElasticsearchQueryType.Lucene;
 
     let i, j, pv, nestedAggs, metric;
     const query = {
@@ -420,6 +421,10 @@ export class ElasticQueryBuilder {
     };
   }
 
+  addPPLAdhocFilters(queryString: any, adhocFilters: any) {
+    return queryString;
+  }
+
   buildPPLQuery(target: any, adhocFilters?: any, queryString?: string) {
     // make sure query has defaults
     target.format = target.format || queryDef.defaultPPLFormat();
@@ -430,6 +435,9 @@ export class ElasticQueryBuilder {
       target.isLogsQuery = true;
     } else {
       target.isLogsQuery = false;
+    }
+    if (adhocFilters) {
+      queryString = this.addPPLAdhocFilters(queryString, adhocFilters);
     }
 
     const timeRangeFilter = " | where $timestamp > timestamp('$timeFrom') and $timestamp < timestamp('$timeTo')";

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -1,5 +1,5 @@
 import * as queryDef from './query_def';
-import { ElasticsearchAggregation } from './types';
+import { ElasticsearchAggregation, ElasticsearchQueryType } from './types';
 
 export class ElasticQueryBuilder {
   timeField: string;
@@ -418,5 +418,35 @@ export class ElasticQueryBuilder {
       ...query,
       aggs: this.build(target, null, querystring).aggs,
     };
+  }
+
+  buildPPLQuery(target: any, adhocFilters?: any, queryString?: string) {
+    // make sure query has defaults
+    target.format = target.format || queryDef.defaultPPLFormat();
+    target.queryType = ElasticsearchQueryType.PPL;
+
+    // set isLogsQuery depending on the format
+    if (target.format === 'logs') {
+      target.isLogsQuery = true;
+    } else {
+      target.isLogsQuery = false;
+    }
+
+    const timeRangeFilter = " | where $timestamp > timestamp('$timeFrom') and $timestamp < timestamp('$timeTo')";
+    //time range filter must be placed before other query filters
+    if (queryString) {
+      const separatorIndex = queryString.indexOf('|');
+      if (separatorIndex === -1) {
+        queryString = queryString.trimEnd() + timeRangeFilter;
+      } else {
+        queryString =
+          queryString.slice(0, separatorIndex).trimEnd() +
+          timeRangeFilter +
+          ' |' +
+          queryString.slice(separatorIndex + 1);
+      }
+    }
+
+    return { query: queryString };
   }
 }

--- a/public/app/plugins/datasource/elasticsearch/query_def.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_def.ts
@@ -182,6 +182,12 @@ export const movingAvgModelSettings: any = {
   ],
 };
 
+export const pplFormatTypes = [
+  { text: 'Table', value: 'table' },
+  { text: 'Logs', value: 'logs' },
+  { text: 'Time series', value: 'time_series' },
+];
+
 export function getMetricAggTypes(esVersion: any) {
   return _.filter(metricAggTypes, f => {
     if (f.minVersion || f.maxVersion) {
@@ -297,6 +303,10 @@ export function defaultMetricAgg() {
 
 export function defaultBucketAgg() {
   return { type: 'date_histogram', id: '2', settings: { interval: 'auto' } };
+}
+
+export function defaultPPLFormat() {
+  return 'table';
 }
 
 export const findMetricById = (metrics: any[], id: any) => {

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -9,6 +9,7 @@ export interface ElasticsearchOptions extends DataSourceJsonData {
   logMessageField?: string;
   logLevelField?: string;
   dataLinks?: DataLinkConfig[];
+  pplSupportEnabled?: boolean;
 }
 
 export interface ElasticsearchAggregation {
@@ -23,8 +24,10 @@ export interface ElasticsearchQuery extends DataQuery {
   isLogsQuery: boolean;
   alias?: string;
   query?: string;
+  queryType?: ElasticsearchQueryType;
   bucketAggs?: ElasticsearchAggregation[];
   metrics?: ElasticsearchAggregation[];
+  format?: string;
 }
 
 export type DataLinkConfig = {
@@ -32,3 +35,8 @@ export type DataLinkConfig = {
   url: string;
   datasourceUid?: string;
 };
+
+export enum ElasticsearchQueryType {
+  Lucene = 'lucene',
+  PPL = 'PPL',
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is one of several PRs targeting the elasticsearch-ppl-support-frontend branch, which should ultimately contain all the changes required for basic PPL support from the Elasticsearch plugin on the client-side. Basic PPL support entails being able to write PPL queries in the query editor and visualize responses from Elasticsearch instances with the ODFE SQL plugin installed. Expected functionality such as variable interpolation and ad hoc filtering should also work with PPL queries. Features that are out of scope for the elasticsearch-ppl-support-frontend branch include alerting on PPL queries and the option to use PPL queries in the dashboard settings menu.

This PR implements the query builder component for PPL support. The default PPL query is set to request for all data fields in the index specified by the user when configuring the Elasticsearch datasource. The PPL query builder also includes a time range filter by default to ensure the response is in the range specified by the user through the Grafana’s time range drop down menu. 

Note that support for Ad hoc filter through Grafana Variables is not included in this PR but will be implemented in a separate PR.

**Which issue(s) this PR fixes**:

Partially resolves Grafana issue 28674

**Special notes for your reviewer**:

The relevant issue is not linked to avoid having this PR referenced in the issue conversation upstream.

cc: @alolita @robbierolin