### PR TITLE
Elasticsearch: Add PPL Backend Support

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -360,7 +360,7 @@ func (c *baseClientImpl) encodePPLRequests(requests *pplRequest) ([]byte, error)
 	}
 
 	body := string(reqBody)
-	//replace the escaped characters in time range filtering
+	// replace the escaped characters in time range filtering
 	body = strings.ReplaceAll(body, "\\u003c", "<")
 	body = strings.ReplaceAll(body, "\\u003e", ">")
 

--- a/pkg/tsdb/elasticsearch/client/client.go
+++ b/pkg/tsdb/elasticsearch/client/client.go
@@ -39,8 +39,8 @@ type Client interface {
 	GetIndex() string
 	ExecuteMultisearch(r *MultiSearchRequest) (*MultiSearchResponse, error)
 	MultiSearch() *MultiSearchRequestBuilder
-	ExecutePPLQuery(r *PPLQuery) (*PPLResponse, error)
-	PPL() *PPLQueryBuilder
+	ExecutePPLQuery(r *PPLRequest) (*PPLResponse, error)
+	PPL() *PPLRequestBuilder
 	EnableDebug()
 }
 
@@ -436,7 +436,7 @@ func (c *baseClientImpl) executePPLQueryRequest(method, uriPath string, body []b
 	}, nil
 }
 
-func (c *baseClientImpl) ExecutePPLQuery(r *PPLQuery) (*PPLResponse, error) {
+func (c *baseClientImpl) ExecutePPLQuery(r *PPLRequest) (*PPLResponse, error) {
 	clientLog.Debug("Executing PPL", "PPL requests")
 
 	req := createPPLRequest(r)
@@ -497,13 +497,13 @@ func (c *baseClientImpl) ExecutePPLQuery(r *PPLQuery) (*PPLResponse, error) {
 	return &pr, nil
 }
 
-func createPPLRequest(requests *PPLQuery) *pplRequest {
+func createPPLRequest(requests *PPLRequest) *pplRequest {
 	ppl := pplRequest{
 		body: requests,
 	}
 	return &ppl
 }
 
-func (c *baseClientImpl) PPL() *PPLQueryBuilder {
-	return NewPPLQueryBuilder(c.GetIndex())
+func (c *baseClientImpl) PPL() *PPLRequestBuilder {
+	return NewPPLRequestBuilder(c.GetIndex())
 }

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -405,7 +405,7 @@ func TestClient(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					Convey("and replace index pattern with wildcard", func() {
-						So(jBody.Get("query").MustString(), ShouldEqual, "source = metrics-* | where `@timestamp` > timestamp('$timeFrom') and `@timestamp` < timestamp('$timeTo')")
+						So(jBody.Get("query").MustString(), ShouldEqual, "source = metrics-* | where `@timestamp` >= timestamp('$timeFrom') and `@timestamp` <= timestamp('$timeTo')")
 
 					})
 				})

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -406,7 +406,6 @@ func TestClient(t *testing.T) {
 
 					Convey("and replace index pattern with wildcard", func() {
 						So(jBody.Get("query").MustString(), ShouldEqual, "source = metrics-* | where `@timestamp` >= timestamp('$timeFrom') and `@timestamp` <= timestamp('$timeTo')")
-
 					})
 				})
 				Convey("Should parse response", func() {

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -367,6 +367,59 @@ func TestClient(t *testing.T) {
 			})
 		})
 	})
+
+	Convey("Test PPL elasticsearch client", t, func() {
+		httpClientScenario(t, "Given a fake http client and a v7.0 client with response", &models.DataSource{
+			Database: "[metrics-]YYYY.MM.DD",
+			JsonData: simplejson.NewFromAny(map[string]interface{}{
+				"esVersion": 70,
+				"timeField": "@timestamp",
+				"interval":  "Daily",
+			}),
+		}, func(sc *scenarioContext) {
+			sc.responseBody = `{
+				"responses": [
+					{
+						"schema": [{"name": "count(data)", "type": "string"}, {"name": "timestamp", "type": "timestamp"}],
+						"datarows":  [
+							["2020-12-01 00:39:02.912Z", "1"],
+							["2020-12-01 03:26:21.326Z", "2"],
+							["2020-12-01 03:34:43.399Z", "3"]
+					   ]
+					}
+				]
+			}`
+
+			Convey("When executing PPL", func() {
+				ppl, err := createPPLForTest(sc.client)
+				So(err, ShouldBeNil)
+				res, err := sc.client.ExecutePPLQuery(ppl)
+				So(err, ShouldBeNil)
+
+				Convey("Should send correct request and payload", func() {
+					So(sc.request, ShouldNotBeNil)
+					So(sc.request.Method, ShouldEqual, http.MethodPost)
+					So(sc.request.URL.Path, ShouldEqual, "/_opendistro/_ppl")
+
+					So(sc.requestBody, ShouldNotBeNil)
+
+					bodyBytes := sc.requestBody.Bytes()
+
+					jBody, err := simplejson.NewJson(bodyBytes)
+					So(err, ShouldBeNil)
+
+					Convey("Should replace index pattern with wildcard", func() {
+						So(jBody.Get("query").MustString(), ShouldEqual, "source = metrics-* | where `@timestamp` > timestamp('$timeTo') and `@timestamp` < timestamp('$timeFrom')")
+
+					})
+				})
+				Convey("Should parse response", func() {
+					So(res.Responses, ShouldHaveLength, 1)
+					So(res.Status, ShouldEqual, 200)
+				})
+			})
+		})
+	})
 }
 
 func createMultisearchForTest(c Client) (*MultiSearchRequest, error) {
@@ -380,6 +433,12 @@ func createMultisearchForTest(c Client) (*MultiSearchRequest, error) {
 		})
 	})
 	return msb.Build()
+}
+
+func createPPLForTest(c Client) (*PPLQuery, error) {
+	b := c.PPL()
+	b.AddPPLQueryString(c.GetTimeField(), "$timeTo", "$timeFrom", "")
+	return b.Build()
 }
 
 type scenarioContext struct {

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -408,7 +408,7 @@ func TestClient(t *testing.T) {
 					jBody, err := simplejson.NewJson(bodyBytes)
 					So(err, ShouldBeNil)
 
-					Convey("Should replace index pattern with wildcard", func() {
+					Convey("and replace index pattern with wildcard", func() {
 						So(jBody.Get("query").MustString(), ShouldEqual, "source = metrics-* | where `@timestamp` > timestamp('$timeTo') and `@timestamp` < timestamp('$timeFrom')")
 
 					})
@@ -435,7 +435,7 @@ func createMultisearchForTest(c Client) (*MultiSearchRequest, error) {
 	return msb.Build()
 }
 
-func createPPLForTest(c Client) (*PPLQuery, error) {
+func createPPLForTest(c Client) (*PPLRequest, error) {
 	b := c.PPL()
 	b.AddPPLQueryString(c.GetTimeField(), "$timeTo", "$timeFrom", "")
 	return b.Build()

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -378,15 +378,11 @@ func TestClient(t *testing.T) {
 			}),
 		}, func(sc *scenarioContext) {
 			sc.responseBody = `{
-				"responses": [
-					{
-						"schema": [{"name": "count(data)", "type": "string"}, {"name": "timestamp", "type": "timestamp"}],
-						"datarows":  [
-							["2020-12-01 00:39:02.912Z", "1"],
-							["2020-12-01 03:26:21.326Z", "2"],
-							["2020-12-01 03:34:43.399Z", "3"]
-					   ]
-					}
+				"schema": [{"name": "count(data)", "type": "string"}, {"name": "timestamp", "type": "timestamp"}],
+				"datarows":  [
+					["2020-12-01 00:39:02.912Z", "1"],
+					["2020-12-01 03:26:21.326Z", "2"],
+					["2020-12-01 03:34:43.399Z", "3"]
 				]
 			}`
 
@@ -414,7 +410,8 @@ func TestClient(t *testing.T) {
 					})
 				})
 				Convey("Should parse response", func() {
-					So(res.Responses, ShouldHaveLength, 1)
+					So(res.Schema, ShouldHaveLength, 2)
+					So(res.Datarows, ShouldHaveLength, 3)
 					So(res.Status, ShouldEqual, 200)
 				})
 			})

--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -405,7 +405,7 @@ func TestClient(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					Convey("and replace index pattern with wildcard", func() {
-						So(jBody.Get("query").MustString(), ShouldEqual, "source = metrics-* | where `@timestamp` > timestamp('$timeTo') and `@timestamp` < timestamp('$timeFrom')")
+						So(jBody.Get("query").MustString(), ShouldEqual, "source = metrics-* | where `@timestamp` > timestamp('$timeFrom') and `@timestamp` < timestamp('$timeTo')")
 
 					})
 				})

--- a/pkg/tsdb/elasticsearch/client/index_pattern.go
+++ b/pkg/tsdb/elasticsearch/client/index_pattern.go
@@ -39,7 +39,7 @@ func (ip *staticIndexPattern) GetIndices(timeRange *tsdb.TimeRange) ([]string, e
 	return []string{ip.indexName}, nil
 }
 
-//PPL static index pattern returns the indexName string
+// PPL static index pattern returns the indexName string
 func (ip *staticIndexPattern) GetPPLIndex() (string, error) {
 	return ip.indexName, nil
 }
@@ -92,7 +92,7 @@ func (ip *dynamicIndexPattern) GetIndices(timeRange *tsdb.TimeRange) ([]string, 
 	return indices, nil
 }
 
-/// PPL currently does not support multi-indexing through lists, so a wildcard
+// PPL currently does not support multi-indexing through lists, so a wildcard
 // pattern is used to match all patterns and relies on the time range filter
 // to filter out the incorrect indecies.
 func (ip *dynamicIndexPattern) GetPPLIndex() (string, error) {

--- a/pkg/tsdb/elasticsearch/client/index_pattern_test.go
+++ b/pkg/tsdb/elasticsearch/client/index_pattern_test.go
@@ -274,6 +274,44 @@ func TestIndexPattern(t *testing.T) {
 			So(intervals[4], ShouldEqual, time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC))
 		})
 	})
+
+	Convey("PPL static index patterns", t, func() {
+		pplIndexScenario(noInterval, "data-*", func(indices string) {
+			So(indices, ShouldEqual, "data-*")
+		})
+
+		pplIndexScenario(noInterval, "es-index-name", func(indices string) {
+			So(indices, ShouldEqual, "es-index-name")
+		})
+	})
+
+	Convey("PPL dynamic index patterns", t, func() {
+
+		pplIndexScenario(intervalHourly, "[data-]YYYY.MM.DD.HH", func(indices string) {
+			So(indices, ShouldEqual, "data-*")
+		})
+
+		pplIndexScenario(intervalHourly, "YYYY.MM.DD.HH[-data]", func(indices string) {
+			So(indices, ShouldEqual, "*-data")
+		})
+
+		pplIndexScenario(intervalDaily, "[data-]YYYY.MM.DD", func(indices string) {
+			So(indices, ShouldEqual, "data-*")
+		})
+
+		pplIndexScenario(intervalDaily, "YYYY.MM.DD[-data]", func(indices string) {
+			So(indices, ShouldEqual, "*-data")
+		})
+
+		pplIndexScenario(intervalWeekly, "[data-]GGGG.WW", func(indices string) {
+			So(indices, ShouldEqual, "data-*")
+		})
+
+		pplIndexScenario(intervalWeekly, "GGGG.WW[-data]", func(indices string) {
+			So(indices, ShouldEqual, "*-data")
+		})
+	})
+
 }
 
 func indexPatternScenario(interval string, pattern string, timeRange *tsdb.TimeRange, fn func(indices []string)) {
@@ -284,5 +322,16 @@ func indexPatternScenario(interval string, pattern string, timeRange *tsdb.TimeR
 		indices, err := ip.GetIndices(timeRange)
 		So(err, ShouldBeNil)
 		fn(indices)
+	})
+}
+
+func pplIndexScenario(interval string, pattern string, fn func(index string)) {
+	Convey(fmt.Sprintf("Index pattern (interval=%s, index=%s", interval, pattern), func() {
+		ip, err := newIndexPattern(interval, pattern)
+		So(err, ShouldBeNil)
+		So(ip, ShouldNotBeNil)
+		index, err := ip.GetPPLIndex()
+		So(err, ShouldBeNil)
+		fn(index)
 	})
 }

--- a/pkg/tsdb/elasticsearch/client/index_pattern_test.go
+++ b/pkg/tsdb/elasticsearch/client/index_pattern_test.go
@@ -286,7 +286,6 @@ func TestIndexPattern(t *testing.T) {
 	})
 
 	Convey("PPL dynamic index patterns", t, func() {
-
 		pplIndexScenario(intervalHourly, "[data-]YYYY.MM.DD.HH", func(indices string) {
 			So(indices, ShouldEqual, "data-*")
 		})
@@ -311,7 +310,6 @@ func TestIndexPattern(t *testing.T) {
 			So(indices, ShouldEqual, "*-data")
 		})
 	})
-
 }
 
 func indexPatternScenario(interval string, pattern string, timeRange *tsdb.TimeRange, fn func(indices []string)) {

--- a/pkg/tsdb/elasticsearch/client/models.go
+++ b/pkg/tsdb/elasticsearch/client/models.go
@@ -314,3 +314,53 @@ func (a *PipelineAggregation) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(root)
 }
+
+type pplresponse struct {
+	httpResponse *http.Response
+	reqInfo      *PPLRequestInfo
+}
+
+type PPLRequestInfo struct {
+	Method string `json:"method"`
+	Url    string `json:"url"`
+	Data   string `json:"data"`
+}
+
+type PPLResponseInfo struct {
+	Status int              `json:"status"`
+	Data   *simplejson.Json `json:"data"`
+}
+
+type PPLDebugInfo struct {
+	Request  *PPLRequestInfo  `json:"request"`
+	Response *PPLResponseInfo `json:"response"`
+}
+
+// PPLQuery represents the PPL query object
+type PPLQuery struct {
+	Query string
+}
+
+// MarshalJSON returns the JSON encoding of the PPL query string filter.
+func (f *PPLQuery) MarshalJSON() ([]byte, error) {
+	root := map[string]interface{}{
+		"query": f.Query,
+	}
+
+	return json.Marshal(root)
+}
+
+type Datarow []interface{}
+
+// PPLResponseData represents a PPL response
+type PPLResponseData struct {
+	Schema   []map[string]interface{} `json:"schema"`
+	Datarows []Datarow                `json:"datarows"`
+}
+
+// PPLResponse represents a PPL response
+type PPLResponse struct {
+	Status    int                `json:"status,omitempty"`
+	Responses []*PPLResponseData `json:"responses"`
+	DebugInfo *PPLDebugInfo      `json:"-"`
+}

--- a/pkg/tsdb/elasticsearch/client/models.go
+++ b/pkg/tsdb/elasticsearch/client/models.go
@@ -336,13 +336,13 @@ type PPLDebugInfo struct {
 	Response *PPLResponseInfo `json:"response"`
 }
 
-// PPLQuery represents the PPL query object
-type PPLQuery struct {
+// PPLRequest represents the PPL query object
+type PPLRequest struct {
 	Query string
 }
 
 // MarshalJSON returns the JSON encoding of the PPL query string filter.
-func (f *PPLQuery) MarshalJSON() ([]byte, error) {
+func (f *PPLRequest) MarshalJSON() ([]byte, error) {
 	root := map[string]interface{}{
 		"query": f.Query,
 	}

--- a/pkg/tsdb/elasticsearch/client/models.go
+++ b/pkg/tsdb/elasticsearch/client/models.go
@@ -352,15 +352,10 @@ func (f *PPLRequest) MarshalJSON() ([]byte, error) {
 
 type Datarow []interface{}
 
-// PPLResponseData represents a PPL response
-type PPLResponseData struct {
-	Schema   []map[string]interface{} `json:"schema"`
-	Datarows []Datarow                `json:"datarows"`
-}
-
 // PPLResponse represents a PPL response
 type PPLResponse struct {
-	Status    int                `json:"status,omitempty"`
-	Responses []*PPLResponseData `json:"responses"`
-	DebugInfo *PPLDebugInfo      `json:"-"`
+	Status    int                      `json:"status,omitempty"`
+	Schema    []map[string]interface{} `json:"schema"`
+	Datarows  []Datarow                `json:"datarows"`
+	DebugInfo *PPLDebugInfo            `json:"-"`
 }

--- a/pkg/tsdb/elasticsearch/client/models.go
+++ b/pkg/tsdb/elasticsearch/client/models.go
@@ -322,7 +322,7 @@ type pplresponse struct {
 
 type PPLRequestInfo struct {
 	Method string `json:"method"`
-	Url    string `json:"url"`
+	URL    string `json:"url"`
 	Data   string `json:"data"`
 }
 
@@ -336,15 +336,15 @@ type PPLDebugInfo struct {
 	Response *PPLResponseInfo `json:"response"`
 }
 
-// PPLRequest represents the PPL query object
+// PPLRequest represents the PPL query object.
 type PPLRequest struct {
 	Query string
 }
 
 // MarshalJSON returns the JSON encoding of the PPL query string filter.
-func (f *PPLRequest) MarshalJSON() ([]byte, error) {
+func (req *PPLRequest) MarshalJSON() ([]byte, error) {
 	root := map[string]interface{}{
-		"query": f.Query,
+		"query": req.Query,
 	}
 
 	return json.Marshal(root)

--- a/pkg/tsdb/elasticsearch/client/models.go
+++ b/pkg/tsdb/elasticsearch/client/models.go
@@ -350,12 +350,20 @@ func (f *PPLRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(root)
 }
 
-type Datarow []interface{}
-
 // PPLResponse represents a PPL response
 type PPLResponse struct {
-	Status    int                      `json:"status,omitempty"`
-	Schema    []map[string]interface{} `json:"schema"`
-	Datarows  []Datarow                `json:"datarows"`
-	DebugInfo *PPLDebugInfo            `json:"-"`
+	Status    int                    `json:"status,omitempty"`
+	Error     map[string]interface{} `json:"error"`
+	Schema    []FieldSchema          `json:"schema"`
+	Datarows  []Datarow              `json:"datarows"`
+	DebugInfo *PPLDebugInfo          `json:"-"`
 }
+
+// FieldSchema represents the schema for a single field from the PPL response result set
+type FieldSchema struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// Datarow represents a datarow from the PPL response result set
+type Datarow []interface{}

--- a/pkg/tsdb/elasticsearch/client/ppl_request.go
+++ b/pkg/tsdb/elasticsearch/client/ppl_request.go
@@ -5,33 +5,33 @@ import (
 	"strings"
 )
 
-// PPLFilterQueryBuilder represents a PPL query builder
-type PPLQueryBuilder struct {
+// PPLRequestBuilder represents a PPL request builder
+type PPLRequestBuilder struct {
 	index    string
 	pplQuery string
 }
 
-// NewPPLQueryBuilder create a new PPL query builder
-func NewPPLQueryBuilder(index string) *PPLQueryBuilder {
-	builder := &PPLQueryBuilder{
+// NewPPLRequestBuilder create a new PPL request builder
+func NewPPLRequestBuilder(index string) *PPLRequestBuilder {
+	builder := &PPLRequestBuilder{
 		index: index,
 	}
 	return builder
 }
 
 // Build builds and return a PPL query object
-func (b *PPLQueryBuilder) Build() (*PPLQuery, error) {
+func (b *PPLRequestBuilder) Build() (*PPLRequest, error) {
 	if b == nil {
-		b = NewPPLQueryBuilder(b.index)
+		b = NewPPLRequestBuilder(b.index)
 	}
 
-	return &PPLQuery{
+	return &PPLRequest{
 		Query: b.pplQuery,
 	}, nil
 }
 
 // AddPPLQueryString adds a new PPL query string with time range filter
-func (b *PPLQueryBuilder) AddPPLQueryString(timeField, lte, gte, querystring string) *PPLQueryBuilder {
+func (b *PPLRequestBuilder) AddPPLQueryString(timeField, lte, gte, querystring string) *PPLRequestBuilder {
 	res := []string{}
 	timeFilter := fmt.Sprintf(" where `%s` > timestamp('%s') and `%s` < timestamp('%s')", timeField, lte, timeField, gte)
 

--- a/pkg/tsdb/elasticsearch/client/ppl_request.go
+++ b/pkg/tsdb/elasticsearch/client/ppl_request.go
@@ -19,21 +19,15 @@ func NewPPLQueryBuilder(index string) *PPLQueryBuilder {
 	return builder
 }
 
-// PPLQuery creates and returns a query builder
-func (b *PPLQueryBuilder) PPLQuery() *PPLQueryBuilder {
+// Build builds and return a PPL query object
+func (b *PPLQueryBuilder) Build() (*PPLQuery, error) {
 	if b == nil {
 		b = NewPPLQueryBuilder(b.index)
 	}
-	return b
-}
 
-// Build builds and return a PPL query object
-func (b *PPLQueryBuilder) Build() (*PPLQuery, error) {
-	q := PPLQuery{}
-
-	q.Query = b.pplQuery
-
-	return &q, nil
+	return &PPLQuery{
+		Query: b.pplQuery,
+	}, nil
 }
 
 // AddPPLQueryString adds a new PPL query string with time range filter

--- a/pkg/tsdb/elasticsearch/client/ppl_request.go
+++ b/pkg/tsdb/elasticsearch/client/ppl_request.go
@@ -33,7 +33,7 @@ func (b *PPLRequestBuilder) Build() (*PPLRequest, error) {
 // AddPPLQueryString adds a new PPL query string with time range filter
 func (b *PPLRequestBuilder) AddPPLQueryString(timeField, to, from, querystring string) *PPLRequestBuilder {
 	res := []string{}
-	timeFilter := fmt.Sprintf(" where `%s` > timestamp('%s') and `%s` < timestamp('%s')", timeField, from, timeField, to)
+	timeFilter := fmt.Sprintf(" where `%s` >= timestamp('%s') and `%s` <= timestamp('%s')", timeField, from, timeField, to)
 
 	// Sets a default query if the query string is empty
 	if len(strings.TrimSpace(querystring)) == 0 {

--- a/pkg/tsdb/elasticsearch/client/ppl_request.go
+++ b/pkg/tsdb/elasticsearch/client/ppl_request.go
@@ -21,10 +21,6 @@ func NewPPLRequestBuilder(index string) *PPLRequestBuilder {
 
 // Build builds and return a PPL query object
 func (b *PPLRequestBuilder) Build() (*PPLRequest, error) {
-	if b == nil {
-		b = NewPPLRequestBuilder(b.index)
-	}
-
 	return &PPLRequest{
 		Query: b.pplQuery,
 	}, nil

--- a/pkg/tsdb/elasticsearch/client/ppl_request.go
+++ b/pkg/tsdb/elasticsearch/client/ppl_request.go
@@ -28,7 +28,7 @@ func (b *PPLRequestBuilder) Build() (*PPLRequest, error) {
 
 // AddPPLQueryString adds a new PPL query string with time range filter
 func (b *PPLRequestBuilder) AddPPLQueryString(timeField, to, from, querystring string) *PPLRequestBuilder {
-	res := []string{}
+	var res []string
 	timeFilter := fmt.Sprintf(" where `%s` >= timestamp('%s') and `%s` <= timestamp('%s')", timeField, from, timeField, to)
 
 	// Sets a default query if the query string is empty

--- a/pkg/tsdb/elasticsearch/client/ppl_request.go
+++ b/pkg/tsdb/elasticsearch/client/ppl_request.go
@@ -1,0 +1,58 @@
+package es
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PPLFilterQueryBuilder represents a PPL query builder
+type PPLQueryBuilder struct {
+	index    string
+	pplQuery string
+}
+
+// NewPPLQueryBuilder create a new PPL query builder
+func NewPPLQueryBuilder(index string) *PPLQueryBuilder {
+	builder := &PPLQueryBuilder{
+		index: index,
+	}
+	return builder
+}
+
+// PPLQuery creates and returns a query builder
+func (b *PPLQueryBuilder) PPLQuery() *PPLQueryBuilder {
+	if b == nil {
+		b = NewPPLQueryBuilder(b.index)
+	}
+	return b
+}
+
+// Build builds and return a PPL query object
+func (b *PPLQueryBuilder) Build() (*PPLQuery, error) {
+	q := PPLQuery{}
+
+	q.Query = b.pplQuery
+
+	return &q, nil
+}
+
+// AddPPLQueryString adds a new PPL query string with time range filter
+func (b *PPLQueryBuilder) AddPPLQueryString(timeField, lte, gte, querystring string) *PPLQueryBuilder {
+	res := []string{}
+	timeFilter := fmt.Sprintf(" where `%s` > timestamp('%s') and `%s` < timestamp('%s')", timeField, lte, timeField, gte)
+
+	// Sets a default query if the query string is empty
+	if len(strings.TrimSpace(querystring)) == 0 {
+		querystring = fmt.Sprintf("source = %s", b.index)
+	}
+
+	// Time range filter always come right after the source=[index]
+	querySplit := strings.SplitN(querystring, "|", 2)
+	if len(querySplit) == 1 {
+		res = []string{strings.TrimSpace(querySplit[0]), timeFilter}
+	} else {
+		res = []string{strings.TrimSpace(querySplit[0]), timeFilter, querySplit[1]}
+	}
+	b.pplQuery = strings.Join(res, " |")
+	return b
+}

--- a/pkg/tsdb/elasticsearch/client/ppl_request.go
+++ b/pkg/tsdb/elasticsearch/client/ppl_request.go
@@ -31,9 +31,9 @@ func (b *PPLRequestBuilder) Build() (*PPLRequest, error) {
 }
 
 // AddPPLQueryString adds a new PPL query string with time range filter
-func (b *PPLRequestBuilder) AddPPLQueryString(timeField, lte, gte, querystring string) *PPLRequestBuilder {
+func (b *PPLRequestBuilder) AddPPLQueryString(timeField, to, from, querystring string) *PPLRequestBuilder {
 	res := []string{}
-	timeFilter := fmt.Sprintf(" where `%s` > timestamp('%s') and `%s` < timestamp('%s')", timeField, lte, timeField, gte)
+	timeFilter := fmt.Sprintf(" where `%s` > timestamp('%s') and `%s` < timestamp('%s')", timeField, from, timeField, to)
 
 	// Sets a default query if the query string is empty
 	if len(strings.TrimSpace(querystring)) == 0 {

--- a/pkg/tsdb/elasticsearch/client/ppl_request_test.go
+++ b/pkg/tsdb/elasticsearch/client/ppl_request_test.go
@@ -38,7 +38,7 @@ func TestPPLRequest(t *testing.T) {
 
 					Convey("Should have query string filter", func() {
 						f := pr.Query
-						So(f, ShouldEqual, "source = default_index | where `@timestamp` > timestamp('$timeFrom') and `@timestamp` < timestamp('$timeTo')")
+						So(f, ShouldEqual, "source = default_index | where `@timestamp` >= timestamp('$timeFrom') and `@timestamp` <= timestamp('$timeTo')")
 					})
 
 					Convey("When marshal to JSON should generate correct json", func() {
@@ -46,7 +46,7 @@ func TestPPLRequest(t *testing.T) {
 						So(err, ShouldBeNil)
 						json, err := simplejson.NewJson(body)
 						So(err, ShouldBeNil)
-						So(json.Get("query").Interface(), ShouldEqual, "source = default_index | where `@timestamp` > timestamp('$timeFrom') and `@timestamp` < timestamp('$timeTo')")
+						So(json.Get("query").Interface(), ShouldEqual, "source = default_index | where `@timestamp` >= timestamp('$timeFrom') and `@timestamp` <= timestamp('$timeTo')")
 					})
 				})
 			})
@@ -59,7 +59,7 @@ func TestPPLRequest(t *testing.T) {
 
 					Convey("Should have query string filter", func() {
 						f := pr.Query
-						So(f, ShouldEqual, "source = index | where `@timestamp` > timestamp('$timeFrom') and `@timestamp` < timestamp('$timeTo') | fields test")
+						So(f, ShouldEqual, "source = index | where `@timestamp` >= timestamp('$timeFrom') and `@timestamp` <= timestamp('$timeTo') | fields test")
 					})
 
 					Convey("When marshal to JSON should generate correct json", func() {
@@ -67,7 +67,7 @@ func TestPPLRequest(t *testing.T) {
 						So(err, ShouldBeNil)
 						json, err := simplejson.NewJson(body)
 						So(err, ShouldBeNil)
-						So(json.Get("query").Interface(), ShouldEqual, "source = index | where `@timestamp` > timestamp('$timeFrom') and `@timestamp` < timestamp('$timeTo') | fields test")
+						So(json.Get("query").Interface(), ShouldEqual, "source = index | where `@timestamp` >= timestamp('$timeFrom') and `@timestamp` <= timestamp('$timeTo') | fields test")
 					})
 				})
 			})

--- a/pkg/tsdb/elasticsearch/client/ppl_request_test.go
+++ b/pkg/tsdb/elasticsearch/client/ppl_request_test.go
@@ -14,7 +14,7 @@ func TestPPLRequest(t *testing.T) {
 		timeField := "@timestamp"
 		index := "default_index"
 		Convey("Given new PPL request builder", func() {
-			b := NewPPLQueryBuilder(index)
+			b := NewPPLRequestBuilder(index)
 
 			Convey("When building PPL request", func() {
 				pr, err := b.Build()

--- a/pkg/tsdb/elasticsearch/client/ppl_request_test.go
+++ b/pkg/tsdb/elasticsearch/client/ppl_request_test.go
@@ -38,7 +38,7 @@ func TestPPLRequest(t *testing.T) {
 
 					Convey("Should have query string filter", func() {
 						f := pr.Query
-						So(f, ShouldEqual, "source = default_index | where `@timestamp` > timestamp('$timeTo') and `@timestamp` < timestamp('$timeFrom')")
+						So(f, ShouldEqual, "source = default_index | where `@timestamp` > timestamp('$timeFrom') and `@timestamp` < timestamp('$timeTo')")
 					})
 
 					Convey("When marshal to JSON should generate correct json", func() {
@@ -46,7 +46,7 @@ func TestPPLRequest(t *testing.T) {
 						So(err, ShouldBeNil)
 						json, err := simplejson.NewJson(body)
 						So(err, ShouldBeNil)
-						So(json.Get("query").Interface(), ShouldEqual, "source = default_index | where `@timestamp` > timestamp('$timeTo') and `@timestamp` < timestamp('$timeFrom')")
+						So(json.Get("query").Interface(), ShouldEqual, "source = default_index | where `@timestamp` > timestamp('$timeFrom') and `@timestamp` < timestamp('$timeTo')")
 					})
 				})
 			})
@@ -59,7 +59,7 @@ func TestPPLRequest(t *testing.T) {
 
 					Convey("Should have query string filter", func() {
 						f := pr.Query
-						So(f, ShouldEqual, "source = index | where `@timestamp` > timestamp('$timeTo') and `@timestamp` < timestamp('$timeFrom') | fields test")
+						So(f, ShouldEqual, "source = index | where `@timestamp` > timestamp('$timeFrom') and `@timestamp` < timestamp('$timeTo') | fields test")
 					})
 
 					Convey("When marshal to JSON should generate correct json", func() {
@@ -67,7 +67,7 @@ func TestPPLRequest(t *testing.T) {
 						So(err, ShouldBeNil)
 						json, err := simplejson.NewJson(body)
 						So(err, ShouldBeNil)
-						So(json.Get("query").Interface(), ShouldEqual, "source = index | where `@timestamp` > timestamp('$timeTo') and `@timestamp` < timestamp('$timeFrom') | fields test")
+						So(json.Get("query").Interface(), ShouldEqual, "source = index | where `@timestamp` > timestamp('$timeFrom') and `@timestamp` < timestamp('$timeTo') | fields test")
 					})
 				})
 			})

--- a/pkg/tsdb/elasticsearch/client/ppl_request_test.go
+++ b/pkg/tsdb/elasticsearch/client/ppl_request_test.go
@@ -30,8 +30,7 @@ func TestPPLRequest(t *testing.T) {
 			})
 
 			Convey("When adding default query", func() {
-				query := b.PPLQuery()
-				query.AddPPLQueryString(timeField, "$timeTo", "$timeFrom", "")
+				b.AddPPLQueryString(timeField, "$timeTo", "$timeFrom", "")
 
 				Convey("When building PPL request", func() {
 					pr, err := b.Build()
@@ -52,8 +51,7 @@ func TestPPLRequest(t *testing.T) {
 				})
 			})
 			Convey("When adding PPL query", func() {
-				query := b.PPLQuery()
-				query.AddPPLQueryString(timeField, "$timeTo", "$timeFrom", "source = index | fields test")
+				b.AddPPLQueryString(timeField, "$timeTo", "$timeFrom", "source = index | fields test")
 
 				Convey("When building PPL request", func() {
 					pr, err := b.Build()

--- a/pkg/tsdb/elasticsearch/client/ppl_request_test.go
+++ b/pkg/tsdb/elasticsearch/client/ppl_request_test.go
@@ -1,0 +1,78 @@
+package es
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestPPLRequest(t *testing.T) {
+	Convey("Test elasticsearch PPL request", t, func() {
+		timeField := "@timestamp"
+		index := "default_index"
+		Convey("Given new PPL request builder", func() {
+			b := NewPPLQueryBuilder(index)
+
+			Convey("When building PPL request", func() {
+				pr, err := b.Build()
+				So(err, ShouldBeNil)
+
+				Convey("When marshal to JSON should generate correct json", func() {
+					body, err := json.Marshal(pr)
+					So(err, ShouldBeNil)
+					json, err := simplejson.NewJson(body)
+					So(err, ShouldBeNil)
+					So(json.Get("query").Interface(), ShouldEqual, "")
+				})
+			})
+
+			Convey("When adding default query", func() {
+				query := b.PPLQuery()
+				query.AddPPLQueryString(timeField, "$timeTo", "$timeFrom", "")
+
+				Convey("When building PPL request", func() {
+					pr, err := b.Build()
+					So(err, ShouldBeNil)
+
+					Convey("Should have query string filter", func() {
+						f := pr.Query
+						So(f, ShouldEqual, "source = default_index | where `@timestamp` > timestamp('$timeTo') and `@timestamp` < timestamp('$timeFrom')")
+					})
+
+					Convey("When marshal to JSON should generate correct json", func() {
+						body, err := json.Marshal(pr)
+						So(err, ShouldBeNil)
+						json, err := simplejson.NewJson(body)
+						So(err, ShouldBeNil)
+						So(json.Get("query").Interface(), ShouldEqual, "source = default_index | where `@timestamp` > timestamp('$timeTo') and `@timestamp` < timestamp('$timeFrom')")
+					})
+				})
+			})
+			Convey("When adding PPL query", func() {
+				query := b.PPLQuery()
+				query.AddPPLQueryString(timeField, "$timeTo", "$timeFrom", "source = index | fields test")
+
+				Convey("When building PPL request", func() {
+					pr, err := b.Build()
+					So(err, ShouldBeNil)
+
+					Convey("Should have query string filter", func() {
+						f := pr.Query
+						So(f, ShouldEqual, "source = index | where `@timestamp` > timestamp('$timeTo') and `@timestamp` < timestamp('$timeFrom') | fields test")
+					})
+
+					Convey("When marshal to JSON should generate correct json", func() {
+						body, err := json.Marshal(pr)
+						So(err, ShouldBeNil)
+						json, err := simplejson.NewJson(body)
+						So(err, ShouldBeNil)
+						So(json.Get("query").Interface(), ShouldEqual, "source = index | where `@timestamp` > timestamp('$timeTo') and `@timestamp` < timestamp('$timeFrom') | fields test")
+					})
+				})
+			})
+		})
+	})
+}

--- a/pkg/tsdb/elasticsearch/lucene_handler.go
+++ b/pkg/tsdb/elasticsearch/lucene_handler.go
@@ -1,0 +1,270 @@
+package elasticsearch
+
+import (
+	"strconv"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/tsdb"
+	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
+)
+
+type luceneHandler struct {
+	client             es.Client
+	tsdbQuery          *tsdb.TsdbQuery
+	intervalCalculator tsdb.IntervalCalculator
+	ms                 *es.MultiSearchRequestBuilder
+	queries            []*Query
+}
+
+var newLuceneHandler = func(client es.Client, tsdbQuery *tsdb.TsdbQuery, intervalCalculator tsdb.IntervalCalculator) *luceneHandler {
+	return &luceneHandler{
+		client:             client,
+		tsdbQuery:          tsdbQuery,
+		intervalCalculator: intervalCalculator,
+		ms:                 client.MultiSearch(),
+		queries:            make([]*Query, 0),
+	}
+}
+
+func (h *luceneHandler) processQuery(q *Query, from, to string) error {
+	minInterval, err := h.client.GetMinInterval(q.Interval)
+	if err != nil {
+		return err
+	}
+	interval := h.intervalCalculator.Calculate(h.tsdbQuery.TimeRange, minInterval)
+
+	h.queries = append(h.queries, q)
+
+	b := h.ms.Search(interval)
+	b.Size(0)
+	filters := b.Query().Bool().Filter()
+	filters.AddDateRangeFilter(h.client.GetTimeField(), to, from, es.DateFormatEpochMS)
+
+	if q.RawQuery != "" {
+		filters.AddQueryStringFilter(q.RawQuery, true)
+	}
+
+	if len(q.BucketAggs) == 0 {
+		if len(q.Metrics) == 0 || q.Metrics[0].Type != "raw_document" {
+			return nil
+		}
+		metric := q.Metrics[0]
+		b.Size(metric.Settings.Get("size").MustInt(500))
+		b.SortDesc("@timestamp", "boolean")
+		b.AddDocValueField("@timestamp")
+		return nil
+	}
+
+	aggBuilder := b.Agg()
+
+	// iterate backwards to create aggregations bottom-down
+	for _, bucketAgg := range q.BucketAggs {
+		switch bucketAgg.Type {
+		case dateHistType:
+			aggBuilder = addDateHistogramAgg(aggBuilder, bucketAgg, from, to)
+		case histogramType:
+			aggBuilder = addHistogramAgg(aggBuilder, bucketAgg)
+		case filtersType:
+			aggBuilder = addFiltersAgg(aggBuilder, bucketAgg)
+		case termsType:
+			aggBuilder = addTermsAgg(aggBuilder, bucketAgg, q.Metrics)
+		case geohashGridType:
+			aggBuilder = addGeoHashGridAgg(aggBuilder, bucketAgg)
+		}
+	}
+
+	for _, m := range q.Metrics {
+		m := m
+		if m.Type == countType {
+			continue
+		}
+
+		if isPipelineAgg(m.Type) {
+			if isPipelineAggWithMultipleBucketPaths(m.Type) {
+				if len(m.PipelineVariables) > 0 {
+					bucketPaths := map[string]interface{}{}
+					for name, pipelineAgg := range m.PipelineVariables {
+						if _, err := strconv.Atoi(pipelineAgg); err == nil {
+							var appliedAgg *MetricAgg
+							for _, pipelineMetric := range q.Metrics {
+								if pipelineMetric.ID == pipelineAgg {
+									appliedAgg = pipelineMetric
+									break
+								}
+							}
+							if appliedAgg != nil {
+								if appliedAgg.Type == countType {
+									bucketPaths[name] = "_count"
+								} else {
+									bucketPaths[name] = pipelineAgg
+								}
+							}
+						}
+					}
+
+					aggBuilder.Pipeline(m.ID, m.Type, bucketPaths, func(a *es.PipelineAggregation) {
+						a.Settings = m.Settings.MustMap()
+					})
+				} else {
+					continue
+				}
+			} else {
+				if _, err := strconv.Atoi(m.PipelineAggregate); err == nil {
+					var appliedAgg *MetricAgg
+					for _, pipelineMetric := range q.Metrics {
+						if pipelineMetric.ID == m.PipelineAggregate {
+							appliedAgg = pipelineMetric
+							break
+						}
+					}
+					if appliedAgg != nil {
+						bucketPath := m.PipelineAggregate
+						if appliedAgg.Type == countType {
+							bucketPath = "_count"
+						}
+
+						aggBuilder.Pipeline(m.ID, m.Type, bucketPath, func(a *es.PipelineAggregation) {
+							a.Settings = m.Settings.MustMap()
+						})
+					}
+				} else {
+					continue
+				}
+			}
+		} else {
+			aggBuilder.Metric(m.ID, m.Type, m.Field, func(a *es.MetricAggregation) {
+				a.Settings = m.Settings.MustMap()
+			})
+		}
+	}
+
+	return nil
+}
+
+func (h *luceneHandler) executeQueries() (*tsdb.Response, error) {
+	req, err := h.ms.Build()
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := h.client.ExecuteMultisearch(req)
+	if err != nil {
+		return nil, err
+	}
+
+	rp := newResponseParser(res.Responses, h.queries, res.DebugInfo)
+	return rp.getTimeSeries()
+}
+
+func addDateHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, timeFrom, timeTo string) es.AggBuilder {
+	aggBuilder.DateHistogram(bucketAgg.ID, bucketAgg.Field, func(a *es.DateHistogramAgg, b es.AggBuilder) {
+		a.Interval = bucketAgg.Settings.Get("interval").MustString("auto")
+		a.MinDocCount = bucketAgg.Settings.Get("min_doc_count").MustInt(0)
+		a.ExtendedBounds = &es.ExtendedBounds{Min: timeFrom, Max: timeTo}
+		a.Format = bucketAgg.Settings.Get("format").MustString(es.DateFormatEpochMS)
+
+		if a.Interval == "auto" {
+			a.Interval = "$__interval"
+		}
+
+		if offset, err := bucketAgg.Settings.Get("offset").String(); err == nil {
+			a.Offset = offset
+		}
+
+		if missing, err := bucketAgg.Settings.Get("missing").String(); err == nil {
+			a.Missing = &missing
+		}
+
+		aggBuilder = b
+	})
+
+	return aggBuilder
+}
+
+func addHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg) es.AggBuilder {
+	aggBuilder.Histogram(bucketAgg.ID, bucketAgg.Field, func(a *es.HistogramAgg, b es.AggBuilder) {
+		a.Interval = bucketAgg.Settings.Get("interval").MustInt(1000)
+		a.MinDocCount = bucketAgg.Settings.Get("min_doc_count").MustInt(0)
+
+		if missing, err := bucketAgg.Settings.Get("missing").Int(); err == nil {
+			a.Missing = &missing
+		}
+
+		aggBuilder = b
+	})
+
+	return aggBuilder
+}
+
+func addTermsAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, metrics []*MetricAgg) es.AggBuilder {
+	aggBuilder.Terms(bucketAgg.ID, bucketAgg.Field, func(a *es.TermsAggregation, b es.AggBuilder) {
+		if size, err := bucketAgg.Settings.Get("size").Int(); err == nil {
+			a.Size = size
+		} else if size, err := bucketAgg.Settings.Get("size").String(); err == nil {
+			a.Size, err = strconv.Atoi(size)
+			if err != nil {
+				a.Size = 500
+			}
+		} else {
+			a.Size = 500
+		}
+		if a.Size == 0 {
+			a.Size = 500
+		}
+
+		if minDocCount, err := bucketAgg.Settings.Get("min_doc_count").Int(); err == nil {
+			a.MinDocCount = &minDocCount
+		}
+		if missing, err := bucketAgg.Settings.Get("missing").String(); err == nil {
+			a.Missing = &missing
+		}
+
+		if orderBy, err := bucketAgg.Settings.Get("orderBy").String(); err == nil {
+			a.Order[orderBy] = bucketAgg.Settings.Get("order").MustString("desc")
+
+			if _, err := strconv.Atoi(orderBy); err == nil {
+				for _, m := range metrics {
+					if m.ID == orderBy {
+						b.Metric(m.ID, m.Type, m.Field, nil)
+						break
+					}
+				}
+			}
+		}
+
+		aggBuilder = b
+	})
+
+	return aggBuilder
+}
+
+func addFiltersAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg) es.AggBuilder {
+	filters := make(map[string]interface{})
+	for _, filter := range bucketAgg.Settings.Get("filters").MustArray() {
+		json := simplejson.NewFromAny(filter)
+		query := json.Get("query").MustString()
+		label := json.Get("label").MustString()
+		if label == "" {
+			label = query
+		}
+		filters[label] = &es.QueryStringFilter{Query: query, AnalyzeWildcard: true}
+	}
+
+	if len(filters) > 0 {
+		aggBuilder.Filters(bucketAgg.ID, func(a *es.FiltersAggregation, b es.AggBuilder) {
+			a.Filters = filters
+			aggBuilder = b
+		})
+	}
+
+	return aggBuilder
+}
+
+func addGeoHashGridAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg) es.AggBuilder {
+	aggBuilder.GeoHashGrid(bucketAgg.ID, bucketAgg.Field, func(a *es.GeoHashGridAggregation, b es.AggBuilder) {
+		a.Precision = bucketAgg.Settings.Get("precision").MustInt(3)
+		aggBuilder = b
+	})
+
+	return aggBuilder
+}

--- a/pkg/tsdb/elasticsearch/lucene_handler.go
+++ b/pkg/tsdb/elasticsearch/lucene_handler.go
@@ -1,6 +1,7 @@
 package elasticsearch
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -26,7 +27,10 @@ var newLuceneHandler = func(client es.Client, tsdbQuery *tsdb.TsdbQuery, interva
 	}
 }
 
-func (h *luceneHandler) processQuery(q *Query, from, to string) error {
+func (h *luceneHandler) processQuery(q *Query) error {
+	from := fmt.Sprintf("%d", h.tsdbQuery.TimeRange.GetFromAsMsEpoch())
+	to := fmt.Sprintf("%d", h.tsdbQuery.TimeRange.GetToAsMsEpoch())
+
 	minInterval, err := h.client.GetMinInterval(q.Interval)
 	if err != nil {
 		return err

--- a/pkg/tsdb/elasticsearch/models.go
+++ b/pkg/tsdb/elasticsearch/models.go
@@ -2,17 +2,25 @@ package elasticsearch
 
 import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/tsdb"
 )
 
 // Query represents the time series query model of the datasource
 type Query struct {
 	TimeField  string       `json:"timeField"`
 	RawQuery   string       `json:"query"`
+	QueryType  string       `json:"queryType"`
 	BucketAggs []*BucketAgg `json:"bucketAggs"`
 	Metrics    []*MetricAgg `json:"metrics"`
 	Alias      string       `json:"alias"`
 	Interval   string
 	RefID      string
+}
+
+// queryHandler is an interface for handling queries of the same type
+type queryHandler interface {
+	processQuery(q *Query, from, to string) error
+	executeQueries() (*tsdb.Response, error)
 }
 
 // BucketAgg represents a bucket aggregation of the time series query model of the datasource

--- a/pkg/tsdb/elasticsearch/models.go
+++ b/pkg/tsdb/elasticsearch/models.go
@@ -104,3 +104,9 @@ func describeMetric(metricType, field string) string {
 	}
 	return text + " " + field
 }
+
+// PPL date time type formats
+const (
+	pplTSFormat   = "2006-01-02 15:04:05.000000"
+	pplDateFormat = "2006-01-02"
+)

--- a/pkg/tsdb/elasticsearch/models.go
+++ b/pkg/tsdb/elasticsearch/models.go
@@ -19,7 +19,7 @@ type Query struct {
 
 // queryHandler is an interface for handling queries of the same type
 type queryHandler interface {
-	processQuery(q *Query, from, to string) error
+	processQuery(q *Query) error
 	executeQueries() (*tsdb.Response, error)
 }
 

--- a/pkg/tsdb/elasticsearch/ppl_handler.go
+++ b/pkg/tsdb/elasticsearch/ppl_handler.go
@@ -1,0 +1,50 @@
+package elasticsearch
+
+import (
+	"github.com/grafana/grafana/pkg/tsdb"
+	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
+)
+
+type pplHandler struct {
+	client    es.Client
+	tsdbQuery *tsdb.TsdbQuery
+	builders  map[string]*es.PPLRequestBuilder
+}
+
+var newPPLHandler = func(client es.Client, tsdbQuery *tsdb.TsdbQuery) *pplHandler {
+	return &pplHandler{
+		client:    client,
+		tsdbQuery: tsdbQuery,
+		builders:  make(map[string]*es.PPLRequestBuilder),
+	}
+}
+
+func (h *pplHandler) processQuery(q *Query, from, to string) error {
+	builder := h.client.PPL()
+	builder.AddPPLQueryString(h.client.GetTimeField(), to, from, q.RawQuery)
+	h.builders[q.RefID] = builder
+	return nil
+}
+
+func (h *pplHandler) executeQueries() (*tsdb.Response, error) {
+	result := &tsdb.Response{}
+	result.Results = make(map[string]*tsdb.QueryResult)
+
+	for refID, builder := range h.builders {
+		req, err := builder.Build()
+		if err != nil {
+			return nil, err
+		}
+		res, err := h.client.ExecutePPLQuery(req)
+		if err != nil {
+			return nil, err
+		}
+		rp := newPPLResponseParser(res)
+		queryRes, err := rp.parseTimeSeries()
+		if err != nil {
+			return nil, err
+		}
+		result.Results[refID] = queryRes
+	}
+	return result, nil
+}

--- a/pkg/tsdb/elasticsearch/ppl_handler.go
+++ b/pkg/tsdb/elasticsearch/ppl_handler.go
@@ -19,7 +19,10 @@ var newPPLHandler = func(client es.Client, tsdbQuery *tsdb.TsdbQuery) *pplHandle
 	}
 }
 
-func (h *pplHandler) processQuery(q *Query, from, to string) error {
+func (h *pplHandler) processQuery(q *Query) error {
+	from := h.tsdbQuery.TimeRange.MustGetFrom().Local().Format("2006-01-02 15:04:05")
+	to := h.tsdbQuery.TimeRange.MustGetTo().Local().Format("2006-01-02 15:04:05")
+
 	builder := h.client.PPL()
 	builder.AddPPLQueryString(h.client.GetTimeField(), to, from, q.RawQuery)
 	h.builders[q.RefID] = builder

--- a/pkg/tsdb/elasticsearch/ppl_response_parser.go
+++ b/pkg/tsdb/elasticsearch/ppl_response_parser.go
@@ -13,13 +13,11 @@ import (
 
 type pplResponseParser struct {
 	Response *es.PPLResponse
-	Target   *Query
 }
 
-var newPPLResponseParser = func(response *es.PPLResponse, target *Query) *pplResponseParser {
+var newPPLResponseParser = func(response *es.PPLResponse) *pplResponseParser {
 	return &pplResponseParser{
 		Response: response,
-		Target:   target,
 	}
 }
 

--- a/pkg/tsdb/elasticsearch/ppl_response_parser.go
+++ b/pkg/tsdb/elasticsearch/ppl_response_parser.go
@@ -1,0 +1,147 @@
+package elasticsearch
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/grafana/grafana/pkg/components/null"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/tsdb"
+	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
+)
+
+type pplResponseParser struct {
+	Response *es.PPLResponse
+	Target   *Query
+}
+
+var newPPLResponseParser = func(response *es.PPLResponse, target *Query) *pplResponseParser {
+	return &pplResponseParser{
+		Response: response,
+		Target:   target,
+	}
+}
+
+// Stores meta info on response object
+type responseMeta struct {
+	valueIndex      int
+	timeFieldIndex  int
+	timeFieldFormat string
+}
+
+func (rp *pplResponseParser) parseTimeSeries() (*tsdb.QueryResult, error) {
+	queryRes := tsdb.NewQueryResult()
+
+	var debugInfo *simplejson.Json
+	if rp.Response.DebugInfo != nil {
+		debugInfo = simplejson.NewFromAny(rp.Response.DebugInfo)
+	}
+
+	queryRes.Meta = debugInfo
+
+	if rp.Response.Error != nil {
+		queryRes = getErrorFromPPLResponse(rp.Response)
+		queryRes.Meta = debugInfo
+		return queryRes, nil
+	}
+
+	t, err := getResponseMeta(rp.Response.Schema)
+	if err != nil {
+		return nil, err
+	}
+
+	var points tsdb.TimeSeriesPoints
+
+	for _, datarow := range rp.Response.Datarows {
+		point, err := rp.parseTimepoint(datarow, t)
+		if err != nil {
+			return nil, err
+		}
+		points = append(points, point)
+	}
+
+	newSeries := tsdb.TimeSeries{
+		Name:   rp.getSeriesName(t.valueIndex),
+		Points: points,
+	}
+
+	queryRes.Series = append(queryRes.Series, &newSeries)
+
+	return queryRes, nil
+}
+
+func (rp *pplResponseParser) parseTimepoint(datarow es.Datarow, t responseMeta) (tsdb.TimePoint, error) {
+	value, err := rp.parseValue(datarow[t.valueIndex])
+	if err != nil {
+		return tsdb.TimePoint{}, err
+	}
+	timestampNumber, err := rp.parseTimestamp(datarow[t.timeFieldIndex], t.timeFieldFormat)
+	if err != nil {
+		return tsdb.TimePoint{}, err
+	}
+	return tsdb.NewTimePoint(value, timestampNumber), nil
+}
+
+func (rp *pplResponseParser) parseValue(value interface{}) (null.Float, error) {
+	number, ok := value.(float64)
+	if !ok {
+		return null.FloatFromPtr(nil), errors.New("found non-numerical value in value field")
+	}
+	return null.FloatFrom(number), nil
+}
+
+func (rp *pplResponseParser) parseTimestamp(value interface{}, format string) (float64, error) {
+	timestampString, ok := value.(string)
+	if !ok {
+		return 0, errors.New("unable to parse time field")
+	}
+	timestamp, err := time.Parse(format, timestampString)
+	if err != nil {
+		return 0, err
+	}
+	return float64(timestamp.UnixNano()) / float64(time.Millisecond), nil
+}
+
+func (rp *pplResponseParser) getSeriesName(valueIndex int) string {
+	schema := rp.Response.Schema
+	return schema[valueIndex].Name
+}
+
+func getResponseMeta(schema []es.FieldSchema) (responseMeta, error) {
+	if len(schema) != 2 {
+		return responseMeta{}, fmt.Errorf("response should have 2 fields but found %v", len(schema))
+	}
+	var timeIndex int
+	var format string
+	found := false
+	for i, field := range schema {
+		if field.Type == "timestamp" || field.Type == "datetime" || field.Type == "date" {
+			timeIndex = i
+			found = true
+			if field.Type == "date" {
+				format = pplDateFormat
+			} else {
+				format = pplTSFormat
+			}
+		}
+	}
+	if !found {
+		return responseMeta{}, errors.New("a valid time field type was not found in response")
+	}
+	return responseMeta{valueIndex: 1 - timeIndex, timeFieldIndex: timeIndex, timeFieldFormat: format}, nil
+}
+
+func getErrorFromPPLResponse(response *es.PPLResponse) *tsdb.QueryResult {
+	result := tsdb.NewQueryResult()
+	json := simplejson.NewFromAny(response.Error)
+	reason := json.Get("reason").MustString()
+
+	if reason != "" {
+		result.ErrorString = reason
+	} else {
+		result.ErrorString = "Unknown elasticsearch error response"
+	}
+
+	return result
+}

--- a/pkg/tsdb/elasticsearch/ppl_response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/ppl_response_parser_test.go
@@ -6,10 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/components/simplejson"
 	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
 
-	"github.com/grafana/grafana/pkg/tsdb"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -399,27 +397,6 @@ func TestPPLResponseParser(t *testing.T) {
 }
 
 func newPPLResponseParserForTest(tsdbQueries map[string]string, responseBody string) (*pplResponseParser, error) {
-	from := time.Date(2018, 5, 15, 17, 50, 0, 0, time.UTC)
-	to := time.Date(2018, 5, 15, 17, 55, 0, 0, time.UTC)
-	fromStr := fmt.Sprintf("%d", from.UnixNano()/int64(time.Millisecond))
-	toStr := fmt.Sprintf("%d", to.UnixNano()/int64(time.Millisecond))
-	tsdbQuery := &tsdb.TsdbQuery{
-		Queries:   []*tsdb.Query{},
-		TimeRange: tsdb.NewTimeRange(fromStr, toStr),
-	}
-
-	for refID, tsdbQueryBody := range tsdbQueries {
-		tsdbQueryJSON, err := simplejson.NewJson([]byte(tsdbQueryBody))
-		if err != nil {
-			return nil, err
-		}
-
-		tsdbQuery.Queries = append(tsdbQuery.Queries, &tsdb.Query{
-			Model: tsdbQueryJSON,
-			RefId: refID,
-		})
-	}
-
 	var response es.PPLResponse
 	err := json.Unmarshal([]byte(responseBody), &response)
 	if err != nil {
@@ -432,13 +409,7 @@ func newPPLResponseParserForTest(tsdbQueries map[string]string, responseBody str
 		},
 	}
 
-	tsQueryParser := newTimeSeriesQueryParser()
-	queries, err := tsQueryParser.parse(tsdbQuery)
-	if err != nil {
-		return nil, err
-	}
-
-	return newPPLResponseParser(&response, queries[0]), nil
+	return newPPLResponseParser(&response), nil
 }
 
 func formatUnixMs(ms int64, format string) string {

--- a/pkg/tsdb/elasticsearch/ppl_response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/ppl_response_parser_test.go
@@ -1,0 +1,446 @@
+package elasticsearch
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	es "github.com/grafana/grafana/pkg/tsdb/elasticsearch/client"
+
+	"github.com/grafana/grafana/pkg/tsdb"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+const (
+	pplTSFormat   = "2006-01-02 15:04:05.000000"
+	pplDateFormat = "2006-01-02"
+)
+
+func TestPPLResponseParser(t *testing.T) {
+	Convey("PPL response parser test", t, func() {
+		Convey("Simple time series query", func() {
+			Convey("Time field as first field", func() {
+				targets := map[string]string{
+					"A": `{
+						"timeField": "@timestamp"
+					}`,
+				}
+				response := `{
+					"schema": [
+						{ "name": "timeName", "type": "timestamp" },
+						{ "name": "testMetric", "type": "integer" }
+					],
+					"datarows": [
+						["%s", 10],
+						["%s", 15]
+					],
+					"total": 2,
+					"size": 2
+				}`
+				response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat), formatUnixMs(200, pplTSFormat))
+				rp, err := newPPLResponseParserForTest(targets, response)
+				So(err, ShouldBeNil)
+				queryRes, err := rp.parseTimeSeries()
+				So(err, ShouldBeNil)
+				So(queryRes, ShouldNotBeNil)
+				So(queryRes.Series, ShouldHaveLength, 1)
+				series := queryRes.Series[0]
+				So(series.Name, ShouldEqual, "testMetric")
+				So(series.Points, ShouldHaveLength, 2)
+				So(series.Points[0][0].Float64, ShouldEqual, 10)
+				So(series.Points[0][1].Float64, ShouldEqual, 100)
+				So(series.Points[1][0].Float64, ShouldEqual, 15)
+				So(series.Points[1][1].Float64, ShouldEqual, 200)
+			})
+
+			Convey("Time field as second field", func() {
+				targets := map[string]string{
+					"A": `{
+						"timeField": "@timestamp"
+					}`,
+				}
+				response := `{
+					"schema": [
+						{ "name": "testMetric", "type": "integer" },
+						{ "name": "timeName", "type": "timestamp" }
+					],
+					"datarows": [
+						[20, "%s"],
+						[25, "%s"]
+					],
+					"total": 2,
+					"size": 2
+				}`
+				response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat), formatUnixMs(200, pplTSFormat))
+				rp, err := newPPLResponseParserForTest(targets, response)
+				So(err, ShouldBeNil)
+				queryRes, err := rp.parseTimeSeries()
+				So(err, ShouldBeNil)
+				So(queryRes, ShouldNotBeNil)
+				So(queryRes.Series, ShouldHaveLength, 1)
+				series := queryRes.Series[0]
+				So(series.Name, ShouldEqual, "testMetric")
+				So(series.Points, ShouldHaveLength, 2)
+				So(series.Points[0][0].Float64, ShouldEqual, 20)
+				So(series.Points[0][1].Float64, ShouldEqual, 100)
+				So(series.Points[1][0].Float64, ShouldEqual, 25)
+				So(series.Points[1][1].Float64, ShouldEqual, 200)
+			})
+		})
+
+		Convey("Set series name to be value field name", func() {
+			targets := map[string]string{
+				"A": `{
+					"timeField": "@timestamp"
+				}`,
+			}
+			response := `{
+				"schema": [
+					{ "name": "valueField", "type": "integer" },
+					{ "name": "timeName", "type": "timestamp" }
+				],
+				"datarows": [
+					[20, "%s"]
+				],
+				"total": 1,
+				"size": 1
+			}`
+			response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat))
+			rp, err := newPPLResponseParserForTest(targets, response)
+			So(err, ShouldBeNil)
+			queryRes, err := rp.parseTimeSeries()
+			So(err, ShouldBeNil)
+			So(queryRes, ShouldNotBeNil)
+			So(queryRes.Series, ShouldHaveLength, 1)
+			series := queryRes.Series[0]
+			So(series.Name, ShouldEqual, "valueField")
+		})
+
+		Convey("Different date formats", func() {
+			targets := map[string]string{
+				"A": `{
+					"timeField": "@timestamp"
+				}`,
+			}
+			response := `{
+				"schema": [
+					{ "name": "timeName", "type": "%s" },
+					{ "name": "testMetric", "type": "integer" }
+				],
+				"datarows": [
+					["%s", 10]
+				],
+				"total": 1,
+				"size": 1
+			}`
+
+			Convey("Timestamp time field type", func() {
+				formattedResponse := fmt.Sprintf(response, "timestamp", formatUnixMs(100, pplTSFormat))
+				rp, err := newPPLResponseParserForTest(targets, formattedResponse)
+				So(err, ShouldBeNil)
+				queryRes, err := rp.parseTimeSeries()
+				So(err, ShouldBeNil)
+				So(queryRes, ShouldNotBeNil)
+				So(queryRes.Series, ShouldHaveLength, 1)
+				series := queryRes.Series[0]
+				So(series.Name, ShouldEqual, "testMetric")
+				So(series.Points, ShouldHaveLength, 1)
+				So(series.Points[0][0].Float64, ShouldEqual, 10)
+				So(series.Points[0][1].Float64, ShouldEqual, 100)
+			})
+
+			Convey("Datetime time field type", func() {
+				formattedResponse := fmt.Sprintf(response, "datetime", formatUnixMs(100, pplTSFormat))
+				rp, err := newPPLResponseParserForTest(targets, formattedResponse)
+				So(err, ShouldBeNil)
+				queryRes, err := rp.parseTimeSeries()
+				So(err, ShouldBeNil)
+				So(queryRes, ShouldNotBeNil)
+				So(queryRes.Series, ShouldHaveLength, 1)
+				series := queryRes.Series[0]
+				So(series.Name, ShouldEqual, "testMetric")
+				So(series.Points, ShouldHaveLength, 1)
+				So(series.Points[0][0].Float64, ShouldEqual, 10)
+				So(series.Points[0][1].Float64, ShouldEqual, 100)
+			})
+
+			Convey("Date time field type", func() {
+				formattedResponse := fmt.Sprintf(response, "date", formatUnixMs(0, pplDateFormat))
+				rp, err := newPPLResponseParserForTest(targets, formattedResponse)
+				So(err, ShouldBeNil)
+				queryRes, err := rp.parseTimeSeries()
+				So(err, ShouldBeNil)
+				So(queryRes, ShouldNotBeNil)
+				So(queryRes.Series, ShouldHaveLength, 1)
+				series := queryRes.Series[0]
+				So(series.Name, ShouldEqual, "testMetric")
+				So(series.Points, ShouldHaveLength, 1)
+				So(series.Points[0][0].Float64, ShouldEqual, 10)
+				So(series.Points[0][1].Float64, ShouldEqual, 0)
+			})
+		})
+
+		Convey("Handle invalid schema for time series", func() {
+			Convey("More than two fields", func() {
+				targets := map[string]string{
+					"A": `{
+						"timeField": "@timestamp"
+					}`,
+				}
+				response := `{
+				"schema": [
+					{ "name": "testMetric", "type": "integer" },
+					{ "name": "extraMetric", "type": "integer" },
+					{ "name": "timeName", "type": "timestamp" }
+				],
+				"datarows": [
+					[20, 20, "%s"]
+				],
+				"total": 1,
+				"size": 1
+			}`
+				response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat))
+				rp, err := newPPLResponseParserForTest(targets, response)
+				So(err, ShouldBeNil)
+				_, err = rp.parseTimeSeries()
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("Less than two fields", func() {
+				targets := map[string]string{
+					"A": `{
+						"timeField": "@timestamp"
+					}`,
+				}
+				response := `{
+					"schema": [
+						{ "name": "timeName", "type": "timestamp" }
+					],
+					"datarows": [
+						["%s"]
+					],
+					"total": 1,
+					"size": 1
+				}`
+				response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat))
+				rp, err := newPPLResponseParserForTest(targets, response)
+				So(err, ShouldBeNil)
+				_, err = rp.parseTimeSeries()
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("No valid time field type", func() {
+				targets := map[string]string{
+					"A": `{
+						"timeField": "@timestamp"
+					}`,
+				}
+				response := `{
+					"schema": [
+						{ "name": "timeName", "type": "string" },
+						{ "name": "testMetric", "type": "integer" }
+					],
+					"datarows": [
+						["%s", 10]
+					],
+					"total": 1,
+					"size": 1
+				}`
+				response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat))
+				rp, err := newPPLResponseParserForTest(targets, response)
+				So(err, ShouldBeNil)
+				_, err = rp.parseTimeSeries()
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("Valid time field type with invalid value type", func() {
+				targets := map[string]string{
+					"A": `{
+						"timeField": "@timestamp"
+					}`,
+				}
+				response := `{
+					"schema": [
+						{ "name": "timeName", "type": "timestamp" },
+						{ "name": "testMetric", "type": "string" }
+					],
+					"datarows": [
+						["%s", "10"]
+					],
+					"total": 1,
+					"size": 1
+				}`
+				response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat))
+				rp, err := newPPLResponseParserForTest(targets, response)
+				So(err, ShouldBeNil)
+				_, err = rp.parseTimeSeries()
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("Valid schema invalid time field type", func() {
+				targets := map[string]string{
+					"A": `{
+						"timeField": "@timestamp"
+					}`,
+				}
+				response := `{
+					"schema": [
+						{ "name": "timeName", "type": "timestamp" },
+						{ "name": "testMetric", "type": "string" }
+					],
+					"datarows": [
+						[10, "10"]
+					],
+					"total": 1,
+					"size": 1
+				}`
+				rp, err := newPPLResponseParserForTest(targets, response)
+				So(err, ShouldBeNil)
+				_, err = rp.parseTimeSeries()
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("Valid schema invalid time field value", func() {
+				targets := map[string]string{
+					"A": `{
+						"timeField": "@timestamp"
+					}`,
+				}
+				response := `{
+					"schema": [
+						{ "name": "timeName", "type": "timestamp" },
+						{ "name": "testMetric", "type": "string" }
+					],
+					"datarows": [
+						["foo", "10"]
+					],
+					"total": 1,
+					"size": 1
+				}`
+				rp, err := newPPLResponseParserForTest(targets, response)
+				So(err, ShouldBeNil)
+				_, err = rp.parseTimeSeries()
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+		Convey("Parses error response", func() {
+			targets := map[string]string{
+				"A": `{
+					"timeField": "@timestamp"
+				}`,
+			}
+			response := `{
+				"error": {
+					"reason": "Error occurred in Elasticsearch engine: no such index [unknown]",
+					"details": "org.elasticsearch.index.IndexNotFoundException: no such index [unknown].",
+					"type": "IndexNotFoundException"
+				}
+			}`
+			rp, err := newPPLResponseParserForTest(targets, response)
+			So(err, ShouldBeNil)
+			queryRes, err := rp.parseTimeSeries()
+			So(queryRes, ShouldNotBeNil)
+			So(queryRes.ErrorString, ShouldEqual, "Error occurred in Elasticsearch engine: no such index [unknown]")
+			So(queryRes.Series, ShouldHaveLength, 0)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Query result meta field is set", func() {
+			Convey("On successful response", func() {
+				targets := map[string]string{
+					"A": `{
+						"timeField": "@timestamp"
+					}`,
+				}
+				response := `{
+					"schema": [
+						{ "name": "valueField", "type": "integer" },
+						{ "name": "timeName", "type": "timestamp" }
+					],
+					"datarows": [
+						[20, "%s"]
+					],
+					"total": 1,
+					"size": 1
+				}`
+				response = fmt.Sprintf(response, formatUnixMs(100, pplTSFormat))
+				rp, err := newPPLResponseParserForTest(targets, response)
+				So(err, ShouldBeNil)
+				queryRes, err := rp.parseTimeSeries()
+				So(err, ShouldBeNil)
+				So(queryRes, ShouldNotBeNil)
+				So(queryRes.Meta, ShouldNotBeNil)
+			})
+			Convey("On error response", func() {
+				targets := map[string]string{
+					"A": `{
+						"timeField": "@timestamp"
+					}`,
+				}
+				response := `{
+					"error": {
+						"reason": "Error occurred in Elasticsearch engine: no such index [unknown]",
+						"details": "org.elasticsearch.index.IndexNotFoundException: no such index [unknown].",
+						"type": "IndexNotFoundException"
+					}
+				}`
+				rp, err := newPPLResponseParserForTest(targets, response)
+				So(err, ShouldBeNil)
+				queryRes, err := rp.parseTimeSeries()
+				So(err, ShouldBeNil)
+				So(queryRes, ShouldNotBeNil)
+				So(queryRes.Meta, ShouldNotBeNil)
+			})
+		})
+	})
+}
+
+func newPPLResponseParserForTest(tsdbQueries map[string]string, responseBody string) (*pplResponseParser, error) {
+	from := time.Date(2018, 5, 15, 17, 50, 0, 0, time.UTC)
+	to := time.Date(2018, 5, 15, 17, 55, 0, 0, time.UTC)
+	fromStr := fmt.Sprintf("%d", from.UnixNano()/int64(time.Millisecond))
+	toStr := fmt.Sprintf("%d", to.UnixNano()/int64(time.Millisecond))
+	tsdbQuery := &tsdb.TsdbQuery{
+		Queries:   []*tsdb.Query{},
+		TimeRange: tsdb.NewTimeRange(fromStr, toStr),
+	}
+
+	for refID, tsdbQueryBody := range tsdbQueries {
+		tsdbQueryJSON, err := simplejson.NewJson([]byte(tsdbQueryBody))
+		if err != nil {
+			return nil, err
+		}
+
+		tsdbQuery.Queries = append(tsdbQuery.Queries, &tsdb.Query{
+			Model: tsdbQueryJSON,
+			RefId: refID,
+		})
+	}
+
+	var response es.PPLResponse
+	err := json.Unmarshal([]byte(responseBody), &response)
+	if err != nil {
+		return nil, err
+	}
+
+	response.DebugInfo = &es.PPLDebugInfo{
+		Response: &es.PPLResponseInfo{
+			Status: 200,
+		},
+	}
+
+	tsQueryParser := newTimeSeriesQueryParser()
+	queries, err := tsQueryParser.parse(tsdbQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	return newPPLResponseParser(&response, queries[0]), nil
+}
+
+func formatUnixMs(ms int64, format string) string {
+	return time.Unix(0, ms*int64(time.Millisecond)).UTC().Format(format)
+}

--- a/pkg/tsdb/elasticsearch/ppl_response_parser_test.go
+++ b/pkg/tsdb/elasticsearch/ppl_response_parser_test.go
@@ -11,11 +11,6 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-const (
-	pplTSFormat   = "2006-01-02 15:04:05.000000"
-	pplDateFormat = "2006-01-02"
-)
-
 func TestPPLResponseParser(t *testing.T) {
 	Convey("PPL response parser test", t, func() {
 		Convey("Simple time series query", func() {

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -24,269 +24,37 @@ var newTimeSeriesQuery = func(client es.Client, tsdbQuery *tsdb.TsdbQuery, inter
 }
 
 func (e *timeSeriesQuery) execute() (*tsdb.Response, error) {
+	handlers := make(map[string]queryHandler)
+
+	handlers["lucene"] = newLuceneHandler(e.client, e.tsdbQuery, e.intervalCalculator)
+	handlers["PPL"] = newPPLHandler(e.client, e.tsdbQuery)
+
 	tsQueryParser := newTimeSeriesQueryParser()
 	queries, err := tsQueryParser.parse(e.tsdbQuery)
 	if err != nil {
 		return nil, err
 	}
 
-	ms := e.client.MultiSearch()
-
 	from := fmt.Sprintf("%d", e.tsdbQuery.TimeRange.GetFromAsMsEpoch())
 	to := fmt.Sprintf("%d", e.tsdbQuery.TimeRange.GetToAsMsEpoch())
-	result := &tsdb.Response{
-		Results: make(map[string]*tsdb.QueryResult),
-	}
+
 	for _, q := range queries {
-		if err := e.processQuery(q, ms, from, to, result); err != nil {
+		if err := handlers[q.QueryType].processQuery(q, from, to); err != nil {
 			return nil, err
 		}
 	}
 
-	req, err := ms.Build()
-	if err != nil {
-		return nil, err
+	responses := make([]*tsdb.Response, 0)
+
+	for _, handler := range handlers {
+		response, err := handler.executeQueries()
+		if err != nil {
+			return nil, err
+		}
+		responses = append(responses, response)
 	}
 
-	res, err := e.client.ExecuteMultisearch(req)
-	if err != nil {
-		return nil, err
-	}
-
-	rp := newResponseParser(res.Responses, queries, res.DebugInfo)
-	return rp.getTimeSeries()
-}
-
-func (e *timeSeriesQuery) processQuery(q *Query, ms *es.MultiSearchRequestBuilder, from, to string,
-	result *tsdb.Response) error {
-	minInterval, err := e.client.GetMinInterval(q.Interval)
-	if err != nil {
-		return err
-	}
-	interval := e.intervalCalculator.Calculate(e.tsdbQuery.TimeRange, minInterval)
-
-	b := ms.Search(interval)
-	b.Size(0)
-	filters := b.Query().Bool().Filter()
-	filters.AddDateRangeFilter(e.client.GetTimeField(), to, from, es.DateFormatEpochMS)
-
-	if q.RawQuery != "" {
-		filters.AddQueryStringFilter(q.RawQuery, true)
-	}
-
-	if len(q.BucketAggs) == 0 {
-		if len(q.Metrics) == 0 || q.Metrics[0].Type != "raw_document" {
-			result.Results[q.RefID] = &tsdb.QueryResult{
-				RefId:       q.RefID,
-				Error:       fmt.Errorf("invalid query, missing metrics and aggregations"),
-				ErrorString: "invalid query, missing metrics and aggregations",
-			}
-			return nil
-		}
-		metric := q.Metrics[0]
-		b.Size(metric.Settings.Get("size").MustInt(500))
-		b.SortDesc("@timestamp", "boolean")
-		b.AddDocValueField("@timestamp")
-		return nil
-	}
-
-	aggBuilder := b.Agg()
-
-	// iterate backwards to create aggregations bottom-down
-	for _, bucketAgg := range q.BucketAggs {
-		switch bucketAgg.Type {
-		case dateHistType:
-			aggBuilder = addDateHistogramAgg(aggBuilder, bucketAgg, from, to)
-		case histogramType:
-			aggBuilder = addHistogramAgg(aggBuilder, bucketAgg)
-		case filtersType:
-			aggBuilder = addFiltersAgg(aggBuilder, bucketAgg)
-		case termsType:
-			aggBuilder = addTermsAgg(aggBuilder, bucketAgg, q.Metrics)
-		case geohashGridType:
-			aggBuilder = addGeoHashGridAgg(aggBuilder, bucketAgg)
-		}
-	}
-
-	for _, m := range q.Metrics {
-		m := m
-		if m.Type == countType {
-			continue
-		}
-
-		if isPipelineAgg(m.Type) {
-			if isPipelineAggWithMultipleBucketPaths(m.Type) {
-				if len(m.PipelineVariables) > 0 {
-					bucketPaths := map[string]interface{}{}
-					for name, pipelineAgg := range m.PipelineVariables {
-						if _, err := strconv.Atoi(pipelineAgg); err == nil {
-							var appliedAgg *MetricAgg
-							for _, pipelineMetric := range q.Metrics {
-								if pipelineMetric.ID == pipelineAgg {
-									appliedAgg = pipelineMetric
-									break
-								}
-							}
-							if appliedAgg != nil {
-								if appliedAgg.Type == countType {
-									bucketPaths[name] = "_count"
-								} else {
-									bucketPaths[name] = pipelineAgg
-								}
-							}
-						}
-					}
-
-					aggBuilder.Pipeline(m.ID, m.Type, bucketPaths, func(a *es.PipelineAggregation) {
-						a.Settings = m.Settings.MustMap()
-					})
-				} else {
-					continue
-				}
-			} else {
-				if _, err := strconv.Atoi(m.PipelineAggregate); err == nil {
-					var appliedAgg *MetricAgg
-					for _, pipelineMetric := range q.Metrics {
-						if pipelineMetric.ID == m.PipelineAggregate {
-							appliedAgg = pipelineMetric
-							break
-						}
-					}
-					if appliedAgg != nil {
-						bucketPath := m.PipelineAggregate
-						if appliedAgg.Type == countType {
-							bucketPath = "_count"
-						}
-
-						aggBuilder.Pipeline(m.ID, m.Type, bucketPath, func(a *es.PipelineAggregation) {
-							a.Settings = m.Settings.MustMap()
-						})
-					}
-				} else {
-					continue
-				}
-			}
-		} else {
-			aggBuilder.Metric(m.ID, m.Type, m.Field, func(a *es.MetricAggregation) {
-				a.Settings = m.Settings.MustMap()
-			})
-		}
-	}
-
-	return nil
-}
-
-func addDateHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, timeFrom, timeTo string) es.AggBuilder {
-	aggBuilder.DateHistogram(bucketAgg.ID, bucketAgg.Field, func(a *es.DateHistogramAgg, b es.AggBuilder) {
-		a.Interval = bucketAgg.Settings.Get("interval").MustString("auto")
-		a.MinDocCount = bucketAgg.Settings.Get("min_doc_count").MustInt(0)
-		a.ExtendedBounds = &es.ExtendedBounds{Min: timeFrom, Max: timeTo}
-		a.Format = bucketAgg.Settings.Get("format").MustString(es.DateFormatEpochMS)
-
-		if a.Interval == "auto" {
-			a.Interval = "$__interval"
-		}
-
-		if offset, err := bucketAgg.Settings.Get("offset").String(); err == nil {
-			a.Offset = offset
-		}
-
-		if missing, err := bucketAgg.Settings.Get("missing").String(); err == nil {
-			a.Missing = &missing
-		}
-
-		aggBuilder = b
-	})
-
-	return aggBuilder
-}
-
-func addHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg) es.AggBuilder {
-	aggBuilder.Histogram(bucketAgg.ID, bucketAgg.Field, func(a *es.HistogramAgg, b es.AggBuilder) {
-		a.Interval = bucketAgg.Settings.Get("interval").MustInt(1000)
-		a.MinDocCount = bucketAgg.Settings.Get("min_doc_count").MustInt(0)
-
-		if missing, err := bucketAgg.Settings.Get("missing").Int(); err == nil {
-			a.Missing = &missing
-		}
-
-		aggBuilder = b
-	})
-
-	return aggBuilder
-}
-
-func addTermsAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, metrics []*MetricAgg) es.AggBuilder {
-	aggBuilder.Terms(bucketAgg.ID, bucketAgg.Field, func(a *es.TermsAggregation, b es.AggBuilder) {
-		if size, err := bucketAgg.Settings.Get("size").Int(); err == nil {
-			a.Size = size
-		} else if size, err := bucketAgg.Settings.Get("size").String(); err == nil {
-			a.Size, err = strconv.Atoi(size)
-			if err != nil {
-				a.Size = 500
-			}
-		} else {
-			a.Size = 500
-		}
-		if a.Size == 0 {
-			a.Size = 500
-		}
-
-		if minDocCount, err := bucketAgg.Settings.Get("min_doc_count").Int(); err == nil {
-			a.MinDocCount = &minDocCount
-		}
-		if missing, err := bucketAgg.Settings.Get("missing").String(); err == nil {
-			a.Missing = &missing
-		}
-
-		if orderBy, err := bucketAgg.Settings.Get("orderBy").String(); err == nil {
-			a.Order[orderBy] = bucketAgg.Settings.Get("order").MustString("desc")
-
-			if _, err := strconv.Atoi(orderBy); err == nil {
-				for _, m := range metrics {
-					if m.ID == orderBy {
-						b.Metric(m.ID, m.Type, m.Field, nil)
-						break
-					}
-				}
-			}
-		}
-
-		aggBuilder = b
-	})
-
-	return aggBuilder
-}
-
-func addFiltersAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg) es.AggBuilder {
-	filters := make(map[string]interface{})
-	for _, filter := range bucketAgg.Settings.Get("filters").MustArray() {
-		json := simplejson.NewFromAny(filter)
-		query := json.Get("query").MustString()
-		label := json.Get("label").MustString()
-		if label == "" {
-			label = query
-		}
-		filters[label] = &es.QueryStringFilter{Query: query, AnalyzeWildcard: true}
-	}
-
-	if len(filters) > 0 {
-		aggBuilder.Filters(bucketAgg.ID, func(a *es.FiltersAggregation, b es.AggBuilder) {
-			a.Filters = filters
-			aggBuilder = b
-		})
-	}
-
-	return aggBuilder
-}
-
-func addGeoHashGridAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg) es.AggBuilder {
-	aggBuilder.GeoHashGrid(bucketAgg.ID, bucketAgg.Field, func(a *es.GeoHashGridAggregation, b es.AggBuilder) {
-		a.Precision = bucketAgg.Settings.Get("precision").MustInt(3)
-		aggBuilder = b
-	})
-
-	return aggBuilder
+	return mergeResponses(responses...), nil
 }
 
 type timeSeriesQueryParser struct{}
@@ -304,6 +72,7 @@ func (p *timeSeriesQueryParser) parse(tsdbQuery *tsdb.TsdbQuery) ([]*Query, erro
 			return nil, err
 		}
 		rawQuery := model.Get("query").MustString()
+		queryType := model.Get("queryType").MustString("lucene")
 		bucketAggs, err := p.parseBucketAggs(model)
 		if err != nil {
 			return nil, err
@@ -318,6 +87,7 @@ func (p *timeSeriesQueryParser) parse(tsdbQuery *tsdb.TsdbQuery) ([]*Query, erro
 		queries = append(queries, &Query{
 			TimeField:  timeField,
 			RawQuery:   rawQuery,
+			QueryType:  queryType,
 			BucketAggs: bucketAggs,
 			Metrics:    metrics,
 			Alias:      alias,
@@ -384,4 +154,16 @@ func (p *timeSeriesQueryParser) parseMetrics(model *simplejson.Json) ([]*MetricA
 		result = append(result, metric)
 	}
 	return result, nil
+}
+
+func mergeResponses(responses ...*tsdb.Response) *tsdb.Response {
+	result := &tsdb.Response{
+		Results: make(map[string]*tsdb.QueryResult),
+	}
+	for _, response := range responses {
+		for k, v := range response.Results {
+			result.Results[k] = v
+		}
+	}
+	return result
 }

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -1,7 +1,6 @@
 package elasticsearch
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -35,11 +34,8 @@ func (e *timeSeriesQuery) execute() (*tsdb.Response, error) {
 		return nil, err
 	}
 
-	from := fmt.Sprintf("%d", e.tsdbQuery.TimeRange.GetFromAsMsEpoch())
-	to := fmt.Sprintf("%d", e.tsdbQuery.TimeRange.GetToAsMsEpoch())
-
 	for _, q := range queries {
-		if err := handlers[q.QueryType].processQuery(q, from, to); err != nil {
+		if err := handlers[q.QueryType].processQuery(q); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/tsdb/elasticsearch/time_series_query_test.go
+++ b/pkg/tsdb/elasticsearch/time_series_query_test.go
@@ -1,6 +1,7 @@
 package elasticsearch
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -720,6 +721,118 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 				"var1": "_count",
 			})
 		})
+
+		Convey("With empty PPL query string", func() {
+			c := newFakePPLClient(7,
+				`{"schema": [
+				{ "name": "timeName", "type": "timestamp" },
+				{ "name": "testMetric", "type": "integer" }
+			],
+			"datarows": [
+				["2020-12-01 15:04:05.000000", 10],
+				["2020-12-02 16:04:05.000000", 15]
+			]
+			}`)
+			_, err := executeTsdbQuery(c, `{
+				"timeField": "@timestamp",
+				"query": "",
+				"queryType": "PPL"
+			}`, from, to, 15*time.Second)
+			So(err, ShouldBeNil)
+			q := c.pplRequest[0].Query
+			resp := c.pplResponse
+
+			So(q, ShouldEqual, "source = index | where `@timestamp` >= timestamp('2018-05-15 10:50:00') and `@timestamp` <= timestamp('2018-05-15 10:55:00')")
+			So(resp.Datarows, ShouldHaveLength, 2)
+			So(resp.Datarows[0][1], ShouldEqual, 10)
+			So(resp.Schema, ShouldHaveLength, 2)
+			So(resp.Schema[0].Name, ShouldEqual, "timeName")
+		})
+
+		Convey("With PPL query string", func() {
+			c := newFakePPLClient(7,
+				`{"schema": [
+				{ "name": "dateValue", "type": "date" },
+				{ "name": "count(response)", "type": "int" }
+			],
+			"datarows": [
+				["2020-12-02", 5],
+				["2020-12-03", 6]
+			]
+			}`)
+			_, err := executeTsdbQuery(c, `{
+				"timeField": "@timestamp",
+				"query": "source = index | eval dateValue=date(timestamp) | stats count(response) by dateValue",
+				"queryType": "PPL"
+			}`, from, to, 15*time.Second)
+			So(err, ShouldBeNil)
+			q := c.pplRequest[0].Query
+
+			So(q, ShouldEqual, "source = index | where `@timestamp` >= timestamp('2018-05-15 10:50:00') and `@timestamp` <= timestamp('2018-05-15 10:55:00') | eval dateValue=date(timestamp) | stats count(response) by dateValue")
+		})
+
+		Convey("With empty PPL response", func() {
+			c := newFakePPLClient(7,
+				`{
+				"schema": [],
+				"datarows": []
+			}`)
+			_, err := executeTsdbQuery(c, `{
+				"timeField": "@timestamp",
+				"query": "source = test",
+				"queryType": "PPL"
+			}`, from, to, 15*time.Second)
+			So(err.Error(), ShouldEqual, "response should have 2 fields but found 0")
+			q := c.pplRequest[0].Query
+
+			So(q, ShouldEqual, "source = test | where `@timestamp` >= timestamp('2018-05-15 10:50:00') and `@timestamp` <= timestamp('2018-05-15 10:55:00')")
+			So(c.pplResponse.Datarows, ShouldHaveLength, 0)
+			So(c.pplResponse.Schema, ShouldHaveLength, 0)
+		})
+
+		Convey("With invalid PPL response, timestamp type error", func() {
+			c := newFakePPLClient(7,
+				`{"schema": [
+				{ "name": "timeString", "type": "string" },
+				{ "name": "testMetric", "type": "integer" }
+			],
+			"datarows": [
+				["foo", 10],
+				["foo", 15]
+			]
+			}`)
+			_, err := executeTsdbQuery(c, `{
+				"timeField": "@timestamp",
+				"query": "source = test | fields timeString, testMetric",
+				"queryType": "PPL"
+			}`, from, to, 15*time.Second)
+			So(err.Error(), ShouldEqual, "a valid time field type was not found in response")
+			q := c.pplRequest[0].Query
+
+			So(q, ShouldEqual, "source = test | where `@timestamp` >= timestamp('2018-05-15 10:50:00') and `@timestamp` <= timestamp('2018-05-15 10:55:00') | fields timeString, testMetric")
+		})
+
+		Convey("With invalid PPL response, no numeric field", func() {
+			c := newFakePPLClient(7,
+				`{"schema": [
+				{ "name": "timeName", "type": "timestamp" },
+				{ "name": "testMetric", "type": "string" }
+			],
+			"datarows": [
+				["2020-12-01 15:04:05.000000", "foo"],
+				["2020-12-02 16:04:05.000000", "foo"]
+			]
+			}`)
+			_, err := executeTsdbQuery(c, `{
+				"timeField": "@timestamp",
+				"query": "",
+				"queryType": "PPL"
+			}`, from, to, 15*time.Second)
+			So(err.Error(), ShouldEqual, "found non-numerical value in value field")
+			q := c.pplRequest[0].Query
+
+			So(q, ShouldEqual, "source = index | where `@timestamp` >= timestamp('2018-05-15 10:50:00') and `@timestamp` <= timestamp('2018-05-15 10:55:00')")
+		})
 	})
 }
 
@@ -746,6 +859,25 @@ func newFakeClient(version int) *fakeClient {
 		pplRequest:          make([]*es.PPLRequest, 0),
 		pplResponse:         &es.PPLResponse{},
 	}
+}
+
+func newFakePPLClient(version int, responseBody string) *fakeClient {
+	var response *es.PPLResponse
+	err := json.Unmarshal([]byte(responseBody), &response)
+	if err != nil {
+		return nil
+	}
+
+	testClient := &fakeClient{
+		version:             version,
+		timeField:           "@timestamp",
+		index:               "index",
+		multisearchRequests: make([]*es.MultiSearchRequest, 0),
+		multiSearchResponse: &es.MultiSearchResponse{},
+		pplRequest:          make([]*es.PPLRequest, 0),
+		pplResponse:         response,
+	}
+	return testClient
 }
 
 func (c *fakeClient) EnableDebug() {}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is one of several PRs targeting the `elasticsearch-ppl-support-frontend` branch, which should ultimately contain all the changes required for basic PPL support from the Elasticsearch plugin on the client-side. Basic PPL support entails being able to write PPL queries in the query editor and visualize responses from Elasticsearch instances with the ODFE SQL plugin installed. Expected functionality such as variable interpolation and ad hoc filtering should also work with PPL queries. Features that are out of scope for the `elasticsearch-ppl-support-frontend` branch include alerting on PPL queries and the option to use PPL queries in the dashboard settings menu.

This PR implements the PPL backend components to support Grafana Alerting for time series response. New logic and tests were added to handle PPL request builder and the response parser. Changes were also made to extract the existing Lucene query handler from the `time_series_query` to clearly differentiate the handler logic for the two Elasticsearch query language, Lucene and PPL. 

**Which issue(s) this PR fixes**:

Partially resolves Grafana issue 28674

**Special notes for your reviewer**:

The relevant issue is not linked to avoid having this PR referenced in the issue conversation upstream.

cc: @alolita @robbierolin