### PR TITLE
Add PPL Query Editor

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/index.tsx
@@ -23,7 +23,8 @@ export const BucketAggregationsEditor: FunctionComponent<Props> = ({ nextId }) =
         <QueryEditorRow
           key={bucketAgg.id}
           label={index === 0 ? 'Group By' : 'Then By'}
-          onRemoveClick={totalBucketAggs > 1 && (() => dispatch(removeBucketAggregation(bucketAgg.id)))}
+          onRemoveClick={() => dispatch(removeBucketAggregation(bucketAgg.id))}
+          disableRemove={!(totalBucketAggs > 1)}
         >
           <BucketAggregationEditor value={bucketAgg} />
 

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
@@ -5,6 +5,8 @@ import { ElasticsearchQuery } from '../../types';
 
 import { reducer as metricsReducer } from './MetricAggregationsEditor/state/reducer';
 import { reducer as bucketAggsReducer } from './BucketAggregationsEditor/state/reducer';
+import { queryTypeReducer } from './QueryTypeEditor/state';
+import { formatReducer } from './PPLFormatEditor/state';
 import { aliasPatternReducer, queryReducer, initQuery } from './state';
 
 const DatasourceContext = createContext<ElasticDatasource | undefined>(undefined);
@@ -19,9 +21,11 @@ interface Props {
 export const ElasticsearchProvider: FunctionComponent<Props> = ({ children, onChange, query, datasource }) => {
   const reducer = combineReducers({
     query: queryReducer,
+    queryType: queryTypeReducer,
     alias: aliasPatternReducer,
     metrics: metricsReducer,
     bucketAggs: bucketAggsReducer,
+    format: formatReducer,
   });
 
   const dispatch = useStatelessReducer(newState => onChange({ ...query, ...newState }), query, reducer);

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/LuceneEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/LuceneEditor.tsx
@@ -1,0 +1,44 @@
+import React, { FunctionComponent } from 'react';
+import { ElasticsearchQuery, ElasticsearchQueryType } from '../../types';
+import { InlineField, InlineFieldRow, Input, QueryField } from '@grafana/ui';
+import { changeAliasPattern, changeQuery } from './state';
+import { QueryTypeEditor } from './QueryTypeEditor';
+import { MetricAggregationsEditor } from './MetricAggregationsEditor';
+import { BucketAggregationsEditor } from './BucketAggregationsEditor';
+import { useDispatch } from '../../hooks/useStatelessReducer';
+import { useNextId } from '../../hooks/useNextId';
+
+interface Props {
+  query: ElasticsearchQuery['query'];
+}
+
+export const LuceneEditor: FunctionComponent<Props> = ({ query }) => {
+  const dispatch = useDispatch();
+  const nextId = useNextId();
+
+  return (
+    <>
+      <InlineFieldRow>
+        <InlineField label="Query" labelWidth={17} grow>
+          <>
+            <QueryTypeEditor value={ElasticsearchQueryType.Lucene} />
+            <QueryField
+              query={query}
+              // By default QueryField calls onChange if onBlur is not defined, this will trigger a rerender
+              // And slate will claim the focus, making it impossible to leave the field.
+              onBlur={() => {}}
+              onChange={query => dispatch(changeQuery(query))}
+              placeholder="Lucene Query"
+              portalOrigin="elasticsearch"
+            />
+          </>
+        </InlineField>
+        <InlineField label="Alias" labelWidth={15}>
+          <Input placeholder="Alias Pattern" onBlur={e => dispatch(changeAliasPattern(e.currentTarget.value))} />
+        </InlineField>
+      </InlineFieldRow>
+      <MetricAggregationsEditor nextId={nextId} />
+      <BucketAggregationsEditor nextId={nextId} />
+    </>
+  );
+};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/index.tsx
@@ -26,7 +26,8 @@ export const MetricAggregationsEditor: FunctionComponent<Props> = ({ nextId }) =
           label={`Metric (${metric.id})`}
           hidden={metric.hide}
           onHideClick={() => dispatch(toggleMetricVisibility(metric.id))}
-          onRemoveClick={totalMetrics > 1 && (() => dispatch(removeMetric(metric.id)))}
+          onRemoveClick={() => dispatch(removeMetric(metric.id))}
+          disableRemove={!(totalMetrics > 1)}
         >
           <MetricEditor value={metric} />
 

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLEditor.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { PPLEditor } from './PPLEditor';
+import { QueryField } from '@grafana/ui';
+import { QueryTypeEditor } from './QueryTypeEditor';
+import { PPLFormatEditor } from './PPLFormatEditor';
+import { ElasticsearchQuery } from '../../types';
+
+jest.mock('../../hooks/useStatelessReducer', () => ({
+  useDispatch: jest.fn(),
+}));
+
+describe('PPLEditor', () => {
+  const queryString: ElasticsearchQuery['query'] = '';
+
+  it('should render correctly', () => {
+    shallow(<PPLEditor query={queryString} />);
+  });
+
+  it('should render all components of PPL query editor', () => {
+    const wrapper = shallow(<PPLEditor query={queryString} />);
+    const queryField = wrapper.find(QueryField);
+    expect(queryField.length).toBe(1);
+    expect(queryField.prop('query')).toBe(queryString);
+    expect(wrapper.find(QueryTypeEditor).length).toBe(1);
+    expect(wrapper.find(PPLFormatEditor).length).toBe(1);
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLEditor.tsx
@@ -1,9 +1,9 @@
 import React, { FunctionComponent } from 'react';
 import { ElasticsearchQuery, ElasticsearchQueryType } from '../../types';
 import { InlineField, InlineFieldRow, QueryField } from '@grafana/ui';
-import { changeQuery } from './state';
 import { QueryTypeEditor } from './QueryTypeEditor';
 import { PPLFormatEditor } from './PPLFormatEditor';
+import { changeQuery } from './state';
 import { useDispatch } from '../../hooks/useStatelessReducer';
 
 interface Props {
@@ -21,8 +21,6 @@ export const PPLEditor: FunctionComponent<Props> = ({ query }) => {
             <QueryTypeEditor value={ElasticsearchQueryType.PPL} />
             <QueryField
               query={query}
-              // By default QueryField calls onChange if onBlur is not defined, this will trigger a rerender
-              // And slate will claim the focus, making it impossible to leave the field.
               onBlur={() => {}}
               onChange={query => dispatch(changeQuery(query))}
               placeholder="PPL Query"

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLEditor.tsx
@@ -1,0 +1,37 @@
+import React, { FunctionComponent } from 'react';
+import { ElasticsearchQuery, ElasticsearchQueryType } from '../../types';
+import { InlineField, InlineFieldRow, QueryField } from '@grafana/ui';
+import { changeQuery } from './state';
+import { QueryTypeEditor } from './QueryTypeEditor';
+import { PPLFormatEditor } from './PPLFormatEditor';
+import { useDispatch } from '../../hooks/useStatelessReducer';
+
+interface Props {
+  query: ElasticsearchQuery['query'];
+}
+
+export const PPLEditor: FunctionComponent<Props> = ({ query }) => {
+  const dispatch = useDispatch();
+
+  return (
+    <>
+      <InlineFieldRow>
+        <InlineField label="Query" labelWidth={17} grow>
+          <>
+            <QueryTypeEditor value={ElasticsearchQueryType.PPL} />
+            <QueryField
+              query={query}
+              // By default QueryField calls onChange if onBlur is not defined, this will trigger a rerender
+              // And slate will claim the focus, making it impossible to leave the field.
+              onBlur={() => {}}
+              onChange={query => dispatch(changeQuery(query))}
+              placeholder="PPL Query"
+              portalOrigin="elasticsearch"
+            />
+          </>
+        </InlineField>
+      </InlineFieldRow>
+      <PPLFormatEditor />
+    </>
+  );
+};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/HelpMessage.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/HelpMessage.tsx
@@ -1,0 +1,27 @@
+import React, { FunctionComponent } from 'react';
+
+export const HelpMessage: FunctionComponent = () => (
+  <div className="gf-form grafana-info-box">
+    <div>
+      <h5>Table</h5>
+      <ul>
+        <li>return any set of columns</li>
+      </ul>
+      <br />
+      <h5>Logs</h5>
+      <ul>
+        <li>return any set of columns</li>
+      </ul>
+      <br />
+      <h5>Time series</h5>
+      <ul>
+        <li>return column as date, datetime, or timestamp</li>
+        <li>return column with numeric datatype as values</li>
+      </ul>
+      <br />
+      Example PPL query for time series:
+      <br />
+      <code>source=&lt;index&gt; | eval dateValue=timestamp(timestamp) | stats count(response) by dateValue</code>
+    </div>
+  </div>
+);

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/OpenCloseButton.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/OpenCloseButton.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { OpenCloseButton } from './OpenCloseButton';
+
+const onClickMock = jest.fn();
+
+describe('OpenCloseButton', () => {
+  it('should render correctly', () => {
+    shallow(<OpenCloseButton label="label" open={true} onClick={onClickMock} />);
+  });
+
+  it('should call onClick when button is clicked', () => {
+    const wrapper = shallow(<OpenCloseButton label="label" open={true} onClick={onClickMock} />);
+    wrapper.find('button').simulate('click');
+    expect(onClickMock).toBeCalled();
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/OpenCloseButton.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/OpenCloseButton.tsx
@@ -1,0 +1,33 @@
+import { GrafanaTheme } from '@grafana/data';
+import { Icon, stylesFactory, useTheme } from '@grafana/ui';
+import { css, cx } from 'emotion';
+import React, { FunctionComponent } from 'react';
+import { segmentStyles } from '../styles';
+
+const getStyles = stylesFactory((theme: GrafanaTheme) => {
+  return {
+    icon: css`
+      margin-right: ${theme.spacing.xs};
+    `,
+    button: css`
+      justify-content: start;
+    `,
+  };
+});
+
+interface Props {
+  label: string;
+  open: boolean;
+  onClick: () => void;
+}
+
+export const OpenCloseButton: FunctionComponent<Props> = ({ label, open, onClick }) => {
+  const styles = getStyles(useTheme());
+
+  return (
+    <button className={cx('gf-form-label', styles.button, segmentStyles)} onClick={onClick} aria-expanded={open}>
+      <Icon name={open ? 'angle-down' : 'angle-right'} aria-hidden="true" className={styles.icon} />
+      {label}
+    </button>
+  );
+};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/SettingsEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/SettingsEditor.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { SettingsEditor } from './SettingsEditor';
+import { Segment } from '@grafana/ui';
+import { CHANGE_FORMAT, ChangeFormatAction } from './state';
+
+const mockDispatch = jest.fn();
+
+jest.mock('../../../hooks/useStatelessReducer', () => ({
+  useDispatch: jest.fn(() => mockDispatch),
+}));
+
+describe('SettingsEditor', () => {
+  it('should render correctly', () => {
+    shallow(<SettingsEditor value={'time_series'} />);
+  });
+
+  it('should dispatch action on change event', () => {
+    const expectedAction: ChangeFormatAction = {
+      type: CHANGE_FORMAT,
+      payload: { format: 'time_series' },
+    };
+    const wrapper = shallow(<SettingsEditor value={'table'} />);
+    wrapper.find(Segment).simulate('change', { value: 'time_series' });
+    expect(mockDispatch).toHaveBeenCalledWith(expectedAction);
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/SettingsEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/SettingsEditor.tsx
@@ -1,0 +1,37 @@
+import React, { FunctionComponent } from 'react';
+import { SelectableValue } from '@grafana/data';
+import { Segment } from '@grafana/ui';
+import { useDispatch } from '../../../hooks/useStatelessReducer';
+import { changeFormat } from './state';
+import { formatConfig } from './utils';
+import { PPLFormatType } from './formats';
+import { segmentStyles } from '../styles';
+
+const queryTypeOptions: Array<SelectableValue<PPLFormatType>> = Object.entries(formatConfig).map(
+  ([key, { label }]) => ({
+    label,
+    value: key as PPLFormatType,
+  })
+);
+
+const toOption = (format: PPLFormatType) => ({
+  label: formatConfig[format].label,
+  value: format,
+});
+
+interface Props {
+  value: PPLFormatType;
+}
+
+export const SettingsEditor: FunctionComponent<Props> = ({ value }) => {
+  const dispatch = useDispatch();
+
+  return (
+    <Segment
+      className={segmentStyles}
+      options={queryTypeOptions}
+      onChange={e => dispatch(changeFormat(e.value!))}
+      value={toOption(value)}
+    />
+  );
+};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/formats.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/formats.ts
@@ -1,0 +1,1 @@
+export type PPLFormatType = 'table' | 'logs' | 'time_series';

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/index.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/index.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { PPLFormatEditor } from './';
+import { QueryEditorRow } from '../QueryEditorRow';
+import { SettingsEditor } from './SettingsEditor';
+import { OpenCloseButton } from './OpenCloseButton';
+import { HelpMessage } from './HelpMessage';
+
+jest.mock('../ElasticsearchQueryContext', () => ({
+  useQuery: jest.fn(() => ({
+    format: 'time_series',
+  })),
+}));
+
+describe('PPLFormatEditor', () => {
+  it('should render correctly', () => {
+    shallow(<PPLFormatEditor />);
+  });
+
+  it('should render all components of PPL format editor row', () => {
+    const wrapper = shallow(<PPLFormatEditor />);
+    const queryEditorRow = wrapper.find(QueryEditorRow);
+    expect(queryEditorRow.length).toBe(1);
+    expect(queryEditorRow.props().label).toBe('Format');
+    const settingsEditor = wrapper.find(SettingsEditor);
+    expect(settingsEditor.props().value).toBe('time_series');
+    expect(wrapper.find(OpenCloseButton).length).toBe(1);
+    expect(wrapper.find(HelpMessage).length).toBe(0);
+  });
+
+  it('should show help message on click', () => {
+    const wrapper = shallow(<PPLFormatEditor />);
+    wrapper
+      .find(OpenCloseButton)
+      .props()
+      .onClick();
+    expect(wrapper.find(HelpMessage).length).toBe(1);
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/index.tsx
@@ -1,0 +1,23 @@
+import React, { FunctionComponent, useState } from 'react';
+import { defaultPPLFormat } from '../../../query_def';
+import { useQuery } from '../ElasticsearchQueryContext';
+import { QueryEditorRow } from '../QueryEditorRow';
+import { SettingsEditor } from './SettingsEditor';
+import { OpenCloseButton } from './OpenCloseButton';
+import { HelpMessage } from './HelpMessage';
+
+export const PPLFormatEditor: FunctionComponent = () => {
+  const { format } = useQuery();
+
+  const [displayHelp, setDisplayHelp] = useState(false);
+
+  return (
+    <>
+      <QueryEditorRow label="Format">
+        <SettingsEditor value={format ?? defaultPPLFormat()} />
+        <OpenCloseButton label="Show help" open={displayHelp} onClick={() => setDisplayHelp(!displayHelp)} />
+      </QueryEditorRow>
+      {displayHelp && <HelpMessage />}
+    </>
+  );
+};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/state.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/state.test.ts
@@ -1,0 +1,23 @@
+import { reducerTester } from 'test/core/redux/reducerTester';
+import { ElasticsearchQuery } from '../../../types';
+import { changeFormat, formatReducer } from './state';
+
+describe('Query Type Reducer', () => {
+  it('Should correctly set `format`', () => {
+    const expectedFormat: ElasticsearchQuery['format'] = 'time_series';
+
+    reducerTester()
+      .givenReducer(formatReducer, 'table')
+      .whenActionIsDispatched(changeFormat(expectedFormat))
+      .thenStateShouldEqual(expectedFormat);
+  });
+
+  it('Should not change state with other action types', () => {
+    const initialState: ElasticsearchQuery['format'] = 'time_series';
+
+    reducerTester()
+      .givenReducer(formatReducer, initialState)
+      .whenActionIsDispatched({ type: 'THIS ACTION SHOULD NOT HAVE ANY EFFECT IN THIS REDUCER' })
+      .thenStateShouldEqual(initialState);
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/state.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/state.ts
@@ -2,9 +2,9 @@ import { Action } from '../../../hooks/useStatelessReducer';
 import { INIT, InitAction } from '../state';
 import { PPLFormatType } from './formats';
 
-const CHANGE_FORMAT = 'change_format';
+export const CHANGE_FORMAT = 'change_format';
 
-interface ChangeFormatAction extends Action<typeof CHANGE_FORMAT> {
+export interface ChangeFormatAction extends Action<typeof CHANGE_FORMAT> {
   payload: {
     format: PPLFormatType;
   };

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/state.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/state.ts
@@ -1,0 +1,31 @@
+import { Action } from '../../../hooks/useStatelessReducer';
+import { INIT, InitAction } from '../state';
+import { PPLFormatType } from './formats';
+
+const CHANGE_FORMAT = 'change_format';
+
+interface ChangeFormatAction extends Action<typeof CHANGE_FORMAT> {
+  payload: {
+    format: PPLFormatType;
+  };
+}
+
+export const changeFormat = (format: PPLFormatType): ChangeFormatAction => ({
+  type: CHANGE_FORMAT,
+  payload: {
+    format,
+  },
+});
+
+export const formatReducer = (prevFormat: PPLFormatType, action: ChangeFormatAction | InitAction) => {
+  switch (action.type) {
+    case CHANGE_FORMAT:
+      return action.payload.format;
+
+    case INIT:
+      return 'table';
+
+    default:
+      return prevFormat;
+  }
+};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/PPLFormatEditor/utils.ts
@@ -1,0 +1,7 @@
+import { FormatConfiguration } from '../../../types';
+
+export const formatConfig: FormatConfiguration = {
+  table: { label: 'Table' },
+  logs: { label: 'Logs' },
+  time_series: { label: 'Time series' },
+};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorRow.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryEditorRow.tsx
@@ -2,7 +2,6 @@ import { GrafanaTheme } from '@grafana/data';
 import { IconButton, stylesFactory, useTheme } from '@grafana/ui';
 import { getInlineLabelStyles } from '@grafana/ui/src/components/Forms/InlineLabel';
 import { css } from 'emotion';
-import { noop } from 'lodash';
 import React, { FunctionComponent } from 'react';
 
 interface Props {
@@ -10,6 +9,7 @@ interface Props {
   onRemoveClick?: false | (() => void);
   onHideClick?: false | (() => void);
   hidden?: boolean;
+  disableRemove?: boolean;
 }
 
 export const QueryEditorRow: FunctionComponent<Props> = ({
@@ -18,6 +18,7 @@ export const QueryEditorRow: FunctionComponent<Props> = ({
   onRemoveClick,
   onHideClick,
   hidden = false,
+  disableRemove = false,
 }) => {
   const theme = useTheme();
   const styles = getStyles(theme);
@@ -37,15 +38,17 @@ export const QueryEditorRow: FunctionComponent<Props> = ({
             className={styles.icon}
           />
         )}
-        <IconButton
-          name="trash-alt"
-          surface="header"
-          size="sm"
-          className={styles.icon}
-          onClick={onRemoveClick || noop}
-          disabled={!onRemoveClick}
-          aria-label="remove metric"
-        />
+        {onRemoveClick && (
+          <IconButton
+            name="trash-alt"
+            surface="header"
+            size="sm"
+            className={styles.icon}
+            onClick={onRemoveClick}
+            disabled={disableRemove}
+            aria-label="remove metric"
+          />
+        )}
       </div>
       {children}
     </fieldset>

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeEditor/index.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeEditor/index.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { QueryTypeEditor } from './';
+import { Segment } from '@grafana/ui';
+import { ElasticsearchQueryType } from '../../../types';
+import { CHANGE_QUERY_TYPE, ChangeQueryTypeAction } from './state';
+
+const mockDispatch = jest.fn();
+
+jest.mock('../../../hooks/useStatelessReducer', () => ({
+  useDispatch: jest.fn(() => mockDispatch),
+}));
+
+describe('QueryTypeEditor', () => {
+  it('should render correctly', () => {
+    shallow(<QueryTypeEditor value={ElasticsearchQueryType.Lucene} />);
+  });
+
+  it('should dispatch action on change event', () => {
+    const expectedAction: ChangeQueryTypeAction = {
+      type: CHANGE_QUERY_TYPE,
+      payload: { queryType: ElasticsearchQueryType.Lucene },
+    };
+    const wrapper = shallow(<QueryTypeEditor value={ElasticsearchQueryType.PPL} />);
+    wrapper.find(Segment).simulate('change', { value: ElasticsearchQueryType.Lucene });
+    expect(mockDispatch).toHaveBeenCalledWith(expectedAction);
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeEditor/index.tsx
@@ -1,0 +1,37 @@
+import React, { FunctionComponent } from 'react';
+import { SelectableValue } from '@grafana/data';
+import { Segment } from '@grafana/ui';
+import { useDispatch } from '../../../hooks/useStatelessReducer';
+import { changeQueryType } from './state';
+import { queryTypeConfig } from './utils';
+import { segmentStyles } from '../styles';
+import { ElasticsearchQueryType } from '../../../types';
+
+const queryTypeOptions: Array<SelectableValue<ElasticsearchQueryType>> = Object.entries(queryTypeConfig).map(
+  ([key, { label }]) => ({
+    label,
+    value: key as ElasticsearchQueryType,
+  })
+);
+
+const toOption = (queryType: ElasticsearchQueryType) => ({
+  label: queryTypeConfig[queryType].label,
+  value: queryType,
+});
+
+interface Props {
+  value: ElasticsearchQueryType;
+}
+
+export const QueryTypeEditor: FunctionComponent<Props> = ({ value }) => {
+  const dispatch = useDispatch();
+
+  return (
+    <Segment
+      className={segmentStyles}
+      options={queryTypeOptions}
+      onChange={e => dispatch(changeQueryType(e.value!))}
+      value={toOption(value)}
+    />
+  );
+};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeEditor/state.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeEditor/state.test.ts
@@ -1,0 +1,23 @@
+import { reducerTester } from 'test/core/redux/reducerTester';
+import { ElasticsearchQuery, ElasticsearchQueryType } from '../../../types';
+import { changeQueryType, queryTypeReducer } from './state';
+
+describe('Query Type Reducer', () => {
+  it('Should correctly set `queryType`', () => {
+    const expectedQueryType: ElasticsearchQuery['queryType'] = ElasticsearchQueryType.PPL;
+
+    reducerTester()
+      .givenReducer(queryTypeReducer, ElasticsearchQueryType.Lucene)
+      .whenActionIsDispatched(changeQueryType(expectedQueryType))
+      .thenStateShouldEqual(expectedQueryType);
+  });
+
+  it('Should not change state with other action types', () => {
+    const initialState: ElasticsearchQuery['queryType'] = ElasticsearchQueryType.Lucene;
+
+    reducerTester()
+      .givenReducer(queryTypeReducer, initialState)
+      .whenActionIsDispatched({ type: 'THIS ACTION SHOULD NOT HAVE ANY EFFECT IN THIS REDUCER' })
+      .thenStateShouldEqual(initialState);
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeEditor/state.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeEditor/state.ts
@@ -2,9 +2,9 @@ import { Action } from '../../../hooks/useStatelessReducer';
 import { ElasticsearchQueryType } from '../../../types';
 import { INIT, InitAction } from '../state';
 
-const CHANGE_QUERY_TYPE = 'change_query_type';
+export const CHANGE_QUERY_TYPE = 'change_query_type';
 
-interface ChangeQueryTypeAction extends Action<typeof CHANGE_QUERY_TYPE> {
+export interface ChangeQueryTypeAction extends Action<typeof CHANGE_QUERY_TYPE> {
   payload: {
     queryType: ElasticsearchQueryType;
   };

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeEditor/state.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeEditor/state.ts
@@ -1,0 +1,31 @@
+import { Action } from '../../../hooks/useStatelessReducer';
+import { ElasticsearchQueryType } from '../../../types';
+import { INIT, InitAction } from '../state';
+
+const CHANGE_QUERY_TYPE = 'change_query_type';
+
+interface ChangeQueryTypeAction extends Action<typeof CHANGE_QUERY_TYPE> {
+  payload: {
+    queryType: ElasticsearchQueryType;
+  };
+}
+
+export const changeQueryType = (queryType: ElasticsearchQueryType): ChangeQueryTypeAction => ({
+  type: CHANGE_QUERY_TYPE,
+  payload: {
+    queryType,
+  },
+});
+
+export const queryTypeReducer = (prevQueryType: ElasticsearchQueryType, action: ChangeQueryTypeAction | InitAction) => {
+  switch (action.type) {
+    case CHANGE_QUERY_TYPE:
+      return action.payload.queryType;
+
+    case INIT:
+      return ElasticsearchQueryType.Lucene;
+
+    default:
+      return prevQueryType;
+  }
+};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeEditor/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeEditor/utils.ts
@@ -1,0 +1,6 @@
+import { ElasticsearchQueryType, QueryTypeConfiguration } from '../../../types';
+
+export const queryTypeConfig: QueryTypeConfiguration = {
+  [ElasticsearchQueryType.Lucene]: { label: 'Lucene' },
+  [ElasticsearchQueryType.PPL]: { label: 'PPL' },
+};

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { QueryEditorForm } from './';
+import { LuceneEditor } from './LuceneEditor';
+import { PPLEditor } from './PPLEditor';
+import { ElasticsearchQuery, ElasticsearchQueryType } from '../../types';
+
+describe('QueryEditorForm', () => {
+  it('should render LuceneEditor when queryType is not set', () => {
+    const query: ElasticsearchQuery = {
+      refId: 'A',
+    };
+    const wrapper = shallow(<QueryEditorForm value={query} />);
+    expect(wrapper.find(LuceneEditor).length).toBe(1);
+    expect(wrapper.find(PPLEditor).length).toBe(0);
+  });
+
+  it('should render LuceneEditor given Lucene queryType', () => {
+    const luceneQuery: ElasticsearchQuery = {
+      refId: 'A',
+      queryType: ElasticsearchQueryType.Lucene,
+    };
+    const wrapper = shallow(<QueryEditorForm value={luceneQuery} />);
+    expect(wrapper.find(LuceneEditor).length).toBe(1);
+    expect(wrapper.find(PPLEditor).length).toBe(0);
+  });
+
+  it('should render PPLEditor given PPL queryType', () => {
+    const pplQuery: ElasticsearchQuery = {
+      refId: 'A',
+      queryType: ElasticsearchQueryType.PPL,
+    };
+    const wrapper = shallow(<QueryEditorForm value={pplQuery} />);
+    expect(wrapper.find(LuceneEditor).length).toBe(0);
+    expect(wrapper.find(PPLEditor).length).toBe(1);
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -1,14 +1,10 @@
 import React, { FunctionComponent } from 'react';
 import { QueryEditorProps } from '@grafana/data';
 import { ElasticDatasource } from '../../datasource';
-import { ElasticsearchOptions, ElasticsearchQuery } from '../../types';
+import { ElasticsearchOptions, ElasticsearchQuery, ElasticsearchQueryType } from '../../types';
 import { ElasticsearchProvider } from './ElasticsearchQueryContext';
-import { InlineField, InlineFieldRow, Input, QueryField } from '@grafana/ui';
-import { changeAliasPattern, changeQuery } from './state';
-import { MetricAggregationsEditor } from './MetricAggregationsEditor';
-import { BucketAggregationsEditor } from './BucketAggregationsEditor';
-import { useDispatch } from '../../hooks/useStatelessReducer';
-import { useNextId } from '../../hooks/useNextId';
+import { LuceneEditor } from './LuceneEditor';
+import { PPLEditor } from './PPLEditor';
 
 export type ElasticQueryEditorProps = QueryEditorProps<ElasticDatasource, ElasticsearchQuery, ElasticsearchOptions>;
 
@@ -23,30 +19,12 @@ interface Props {
 }
 
 const QueryEditorForm: FunctionComponent<Props> = ({ value }) => {
-  const dispatch = useDispatch();
-  const nextId = useNextId();
+  const { queryType } = value;
 
-  return (
-    <>
-      <InlineFieldRow>
-        <InlineField label="Query" labelWidth={17} grow>
-          <QueryField
-            query={value.query}
-            // By default QueryField calls onChange if onBlur is not defined, this will trigger a rerender
-            // And slate will claim the focus, making it impossible to leave the field.
-            onBlur={() => {}}
-            onChange={query => dispatch(changeQuery(query))}
-            placeholder="Lucene Query"
-            portalOrigin="elasticsearch"
-          />
-        </InlineField>
-        <InlineField label="Alias" labelWidth={15}>
-          <Input placeholder="Alias Pattern" onBlur={e => dispatch(changeAliasPattern(e.currentTarget.value))} />
-        </InlineField>
-      </InlineFieldRow>
-
-      <MetricAggregationsEditor nextId={nextId} />
-      <BucketAggregationsEditor nextId={nextId} />
-    </>
-  );
+  switch (queryType) {
+    case ElasticsearchQueryType.PPL:
+      return <PPLEditor query={value.query} />;
+    default:
+      return <LuceneEditor query={value.query} />;
+  }
 };

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -18,7 +18,7 @@ interface Props {
   value: ElasticsearchQuery;
 }
 
-const QueryEditorForm: FunctionComponent<Props> = ({ value }) => {
+export const QueryEditorForm: FunctionComponent<Props> = ({ value }) => {
   const { queryType } = value;
 
   switch (queryType) {

--- a/public/app/plugins/datasource/elasticsearch/query_def.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_def.ts
@@ -6,6 +6,7 @@ import {
   MetricAggregationType,
 } from './components/QueryEditor/MetricAggregationsEditor/aggregations';
 import { metricAggregationConfig, pipelineOptions } from './components/QueryEditor/MetricAggregationsEditor/utils';
+import { PPLFormatType } from './components/QueryEditor/PPLFormatEditor/formats';
 
 export const extendedStats: ExtendedStat[] = [
   { label: 'Avg', value: 'avg' },
@@ -49,4 +50,8 @@ export function isPipelineAgg(metricType: MetricAggregationType) {
 
 export function isPipelineAggWithMultipleBucketPaths(metricType: MetricAggregationType) {
   return !!metricAggregationConfig[metricType].supportsMultipleBucketPaths;
+}
+
+export function defaultPPLFormat(): PPLFormatType {
+  return 'table';
 }

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -7,6 +7,7 @@ import {
   MetricAggregation,
   MetricAggregationType,
 } from './components/QueryEditor/MetricAggregationsEditor/aggregations';
+import { PPLFormatType } from './components/QueryEditor/PPLFormatEditor/formats';
 
 export interface ElasticsearchOptions extends DataSourceJsonData {
   timeField: string;
@@ -48,6 +49,14 @@ export type BucketsConfiguration = {
   [P in BucketAggregationType]: BucketConfiguration<P>;
 };
 
+export type QueryTypeConfiguration = {
+  [P in ElasticsearchQueryType]: { label: string };
+};
+
+export type FormatConfiguration = {
+  [P in PPLFormatType]: { label: string };
+};
+
 export interface ElasticsearchAggregation {
   id: string;
   type: MetricAggregationType | BucketAggregationType;
@@ -63,6 +72,8 @@ export interface ElasticsearchQuery extends DataQuery {
   bucketAggs?: BucketAggregation[];
   metrics?: MetricAggregation[];
   timeField?: string;
+  queryType?: ElasticsearchQueryType;
+  format?: PPLFormatType;
 }
 
 export type DataLinkConfig = {
@@ -70,3 +81,8 @@ export type DataLinkConfig = {
   url: string;
   datasourceUid?: string;
 };
+
+export enum ElasticsearchQueryType {
+  Lucene = 'lucene',
+  PPL = 'PPL',
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR contains the addition of a dropdown menu in the Elasticsearch query editor where query syntax can be chosen.

![image](https://user-images.githubusercontent.com/25109478/101710909-4b93d280-3a47-11eb-8253-0c7958acb978.png)

![image](https://user-images.githubusercontent.com/25109478/101710945-61a19300-3a47-11eb-96fd-4e4df81a2512.png)

If Lucene (default) is selected, the query editor should function as before. If PPL is selected, a different query editor interface should appear. The PPL query editor contains a main query input field and an additional dropdown that will be used to determine the visualization format. 

![image](https://user-images.githubusercontent.com/25109478/101710828-21421500-3a47-11eb-85f3-7db1785aec58.png)

![image](https://user-images.githubusercontent.com/25109478/101710782-0a9bbe00-3a47-11eb-98bc-9fabb8771c81.png)

This change is based off of the React refactor of the editor and replaces the [previous PPL editor PR](https://github.com/open-o11y/grafana/pull/3).

**Which issue(s) this PR fixes:**

Partially resolves Grafana issue 28674

**Special notes for your reviewer:**

The relevant issue is not linked to avoid having this PR referenced in the issue conversation upstream.

cc: @alolita @robbierolin