### PR TITLE
Format data frame

### DIFF
--- a/public/app/plugins/panel/geomap/layers/data/utils.ts
+++ b/public/app/plugins/panel/geomap/layers/data/utils.ts
@@ -1,0 +1,99 @@
+import { DataFrame, DataFrameView } from '@grafana/data';
+import { Point } from 'ol/geom';
+import { fromLonLat } from 'ol/proj';
+import { FieldMappingOptions, QueryFormat } from '../../types'
+
+/**
+ * Formats dataframe into Points
+ * @param frame queried data as a DataFrame
+ * @param fieldMapping mapping between location based fields and dataframe
+ * @param queryFormat details format of location data
+ * @returns Point[]
+ */
+export function dataFrameToPoints(frame: DataFrame, fieldMapping: FieldMappingOptions, queryFormat: QueryFormat): Point[] {
+
+  let points: Point[] = [];
+
+  if (frame && frame.length > 0) {
+
+    // For each data point, create a Point
+    const view = new DataFrameView(frame);
+    view.forEach(row => {
+
+      let lng;
+      let lat;
+
+      // Coordinate Data
+      if (queryFormat.locationType === "coordinates") {
+        lng = row[fieldMapping.longitudeField];
+        lat = row[fieldMapping.latitudeField];
+      }
+      // Geohash Data
+      else if (queryFormat.locationType === "geohash"){
+        const encodedGeohash = row[fieldMapping.geohashField];
+        const decodedGeohash = decodeGeohash(encodedGeohash);
+        lng = decodedGeohash.longitude;
+        lat = decodedGeohash.latitude;
+      }
+      points.push(new Point(fromLonLat([lng,lat])));
+    });
+  }
+  return points;
+}
+
+
+/**
+ * Function that decodes input geohash into latitude and longitude
+ * @param geohash short alphanumeric string
+ * @returns map of latitude and longitude
+ */
+export function decodeGeohash(geohash: string) {
+  if (!geohash || geohash.length === 0) {
+    throw new Error('Missing geohash value');
+  }
+  const BITS = [16, 8, 4, 2, 1];
+  const BASE32 = '0123456789bcdefghjkmnpqrstuvwxyz';
+  let isEven = true;
+  const lat: number[] = [];
+  const lon: number[] = [];
+  lat[0] = -90.0;
+  lat[1] = 90.0;
+  lon[0] = -180.0;
+  lon[1] = 180.0;
+  let base32Decoded: number;
+
+  // Enhance location for each character in geohash string
+  geohash.split('').forEach((item: string) => {
+    base32Decoded = BASE32.indexOf(item);
+    BITS.forEach(mask => {
+      if (isEven) {
+        refineInterval(lon, base32Decoded, mask);
+      } 
+      else {
+        refineInterval(lat, base32Decoded, mask);
+      }
+      isEven = !isEven;
+    });
+  });
+  const latCenter = (lat[0] + lat[1]) / 2;
+  const lonCenter = (lon[0] + lon[1]) / 2;
+
+  return { latitude: latCenter, longitude: lonCenter };
+}
+
+/**
+ * Function that decodes input geohash into latitude and longitude
+ * @param interval coordinate interval
+ * @param base32Decoded trasnfer encoding using base32 set
+ * @param mask bitwise operation data
+ * @returns map of latitude and longitude
+ */
+function refineInterval(interval: number[], base32Decoded: number, mask: number) {
+  /* tslint:disable no-bitwise*/
+  if (base32Decoded & mask) {
+    interval[0] = (interval[0] + interval[1]) / 2;
+  } 
+  else {
+    interval[1] = (interval[0] + interval[1]) / 2;
+  }
+}

--- a/public/app/plugins/panel/geomap/types.ts
+++ b/public/app/plugins/panel/geomap/types.ts
@@ -47,6 +47,19 @@ export const defaultView: MapViewConfig = {
 export interface GeomapPanelOptions {
   view: MapViewConfig;
   controls: ControlsOptions;
-  basemap: MapLayerConfig;
-  layers: MapLayerConfig[];
+  basemap: MapLayerConfig; // auto
+  layers: MapLayerConfig[]; // empty == auto
+  fieldMapping: FieldMappingOptions;
+  queryFormat: QueryFormat;
+}
+
+export interface FieldMappingOptions {
+  metricField: string;
+  geohashField: string;
+  latitudeField: string;
+  longitudeField: string;
+}
+
+export interface QueryFormat {
+  locationType: string;
 }


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR implements functionality to format data for the worldmapBehavior and heatmap overlay. Specifically, this PR enables formatting geohash and coordinate based data into an OpenLayer type, Point. 

This PR has three functions:

- **dataFrameToPoints** receives a dataframe object, fieldMappingOptions, and QueryType. The **dataframe** holds the user queried data, which will be translated into an array of Points for the overlay. Furthermore, **fieldMappingOptions and QueryType** hold the data field mapping information. In particular fieldMapping will include user defined mapping about the location based fields, and queryType will include the format that the location data is in.
- **decodeGeoohash** decodes an inputted geohash into coordinates (latitude/longitude).
- **refineInterval** is a helper function used in decodeGeohash.

**Special notes for your reviewer:**
This PR needs to be merged before # 16 